### PR TITLE
templates: Add base title Boost and some specific titles to major pages

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,7 @@
       gtag('config', 'G-1N51ZC252K');
     </script>
 
-    <title>{% block title %}{% endblock %}</title>
+    <title>{% block title %}Boost{% endblock %}</title>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/templates/community_temp.html
+++ b/templates/community_temp.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Boost - Community{% endblock %}
+
 {% block content %}
   <div class="py-0 px-3 mb-3 md:py-6 md:px-0">
     <div class="grid gap-6 grid-cols-1 md:grid-cols-2">

--- a/templates/community_temp.html
+++ b/templates/community_temp.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-
+{% load i18n %}
 {% load static %}
 
-{% block title %}Boost - Community{% endblock %}
+{% block title %}{% trans "Community" %}{% endblock %}
 
 {% block content %}
   <div class="py-0 px-3 mb-3 md:py-6 md:px-0">

--- a/templates/docs_temp.html
+++ b/templates/docs_temp.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-
+{% load i18n %}
 {% load static %}
 
-{% block title %}Boost - Learn{% endblock %}
+{% block title %}{% trans "Learn" %}{% endblock %}
 
 {% comment %}
 This is a temporary landing page for docs

--- a/templates/docs_temp.html
+++ b/templates/docs_temp.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Boost - Learn{% endblock %}
+
 {% comment %}
 This is a temporary landing page for docs
 {% endcomment %}

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Boost - Libraries{% endblock %}
+
 {% block content %}
   <!-- Breadcrumb -->
   <div class="p-3 space-x-2 text-sm divide-x divide-gray-300 md:p-0">

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -2,8 +2,6 @@
 
 {% load static %}
 
-{% block title %}Boost - Libraries{% endblock %}
-
 {% block content %}
   <!-- Breadcrumb -->
   <div class="p-3 space-x-2 text-sm divide-x divide-gray-300 md:p-0">

--- a/templates/libraries/list.html
+++ b/templates/libraries/list.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Boost - Libraries{% endblock %}
+
 {% block content %}
   <!-- Breadcrumb used on filtered views -->
   <div class="p-3 space-x-2 text-sm divide-x divide-gray-300 md:p-0">

--- a/templates/libraries/list.html
+++ b/templates/libraries/list.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-
+{% load i18n %}
 {% load static %}
 
-{% block title %}Boost - Libraries{% endblock %}
+{% block title %}{% trans "Libraries" %}{% endblock %}
 
 {% block content %}
   <!-- Breadcrumb used on filtered views -->

--- a/templates/news/detail.html
+++ b/templates/news/detail.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load static %}
 
-{% block title %}Boost - News{% endblock %}
+{% block title %}{% trans "News" %}{% endblock %}
 
 {% block content %}
   <!-- Breadcrumb used on filtered views -->

--- a/templates/news/detail.html
+++ b/templates/news/detail.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load static %}
 
+{% block title %}Boost - News{% endblock %}
+
 {% block content %}
   <!-- Breadcrumb used on filtered views -->
   <div class="p-3 md:p-0">

--- a/templates/news/list.html
+++ b/templates/news/list.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load static %}
 
+{% block title %}Boost - News{% endblock %}
+
 {% block content %}
   <div class="py-0 px-3 mb-3 md:py-6 md:px-0">
     <div class="md:w-full">

--- a/templates/news/list.html
+++ b/templates/news/list.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load static %}
 
-{% block title %}Boost - News{% endblock %}
+{% block title %}{% trans "News" %}{% endblock %}
 
 {% block content %}
   <div class="py-0 px-3 mb-3 md:py-6 md:px-0">

--- a/templates/releases_temp.html
+++ b/templates/releases_temp.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Boost - Releases{% endblock %}
+
 {% block content %}
   <div class="py-0 px-3 mb-3 md:py-0 md:px-0">
 

--- a/templates/releases_temp.html
+++ b/templates/releases_temp.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-
+{% load i18n %}
 {% load static %}
 
-{% block title %}Boost - Releases{% endblock %}
+{% block title %}{% trans "Releases" %}{% endblock %}
 
 {% block content %}
   <div class="py-0 px-3 mb-3 md:py-0 md:px-0">

--- a/templates/support/contact.html
+++ b/templates/support/contact.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
-
+{% load i18n %}
 {% load static %}
+
+{% block title %}{% trans "Contact Us" %}{% endblock %}
 
 {% block content %}
   <div class="py-0 px-3 mb-3 md:py-6 md:px-0">

--- a/templates/support/getting_started.html
+++ b/templates/support/getting_started.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
-
+{% load i18n %}
 {% load static %}
+
+{% block title %}{% trans "Getting Started" %}{% endblock %}
 
 {% block subnav %}
   <div class="py-8 px-4 space-y-4 text-sm uppercase border-b md:py-2 md:px-0 md:space-x-10 border-slate">

--- a/templates/support/support.html
+++ b/templates/support/support.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
-
+{% load i18n %}
 {% load static %}
+
+{% block title %}{% trans "Support" %}{% endblock %}
 
 {% block subnav %}
   <div class="py-8 px-4 space-y-4 text-sm uppercase border-b md:py-2 md:px-0 md:space-x-10 border-slate">


### PR DESCRIPTION
#308

- Adds base title `Boost` to `base.html` which is used when no title specified

- Adds specific titles to major pages (probably need to be added to translations?)

![index](https://i.imgur.com/BhYsCTs.png)
![news](https://i.imgur.com/TuV3hkw.png)