### PR TITLE
Provide news entry edition and deletion.

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -35,9 +35,11 @@ from mailing_list.views import MailingListView, MailingListDetailView
 from news.views import (
     EntryApproveView,
     EntryCreateView,
+    EntryDeleteView,
     EntryDetailView,
     EntryListView,
     EntryModerationListView,
+    EntryUpdateView,
 )
 from support.views import SupportView, ContactView
 from versions.api import VersionViewSet
@@ -128,6 +130,8 @@ urlpatterns = (
         path(
             "news/<slug:slug>/approve/", EntryApproveView.as_view(), name="news-approve"
         ),
+        path("news/<slug:slug>/delete/", EntryDeleteView.as_view(), name="news-delete"),
+        path("news/<slug:slug>/update/", EntryUpdateView.as_view(), name="news-update"),
         path(
             "people/detail/",
             TemplateView.as_view(template_name="boost/people_detail.html"),

--- a/templates/news/confirm_delete.html
+++ b/templates/news/confirm_delete.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{% translate "Please confirm your choice below" %}</h1>
+<p>{% blocktrans with entry_title=entry.title %}
+Are you sure you want to permanently delete {{ entry_title }}?
+{% endblocktrans %}</p>
+<form method="POST" action="{% url 'news-delete' entry.slug %}">
+  {% csrf_token %}
+  <button type="submit" name="delete">{% translate "Yes, delete" %}</button>
+</form>
+<p><a href="{% url 'news-detail' entry.slug %}">{% translate "No, take me back!" %}</a></p>
+{% endblock %}

--- a/templates/news/detail.html
+++ b/templates/news/detail.html
@@ -30,6 +30,12 @@
           <strong>{% translate "Pending Moderation" %}</strong>
         {% endif %}
       {% endif %}
+      {% if user_can_edit %}
+      <a href="{% url 'news-update' entry.slug %}">{% translate "Edit" %}</a>
+      {% endif %}
+      {% if user_can_delete %}
+      <a href="{% url 'news-delete' entry.slug %}">{% translate "Delete" %}</a>
+      {% endif %}
       </p>
       <!-- END ACTIONS -->
 

--- a/templates/news/update.html
+++ b/templates/news/update.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{% if entry.pk %}{% translate "Edit News" %}{% else %}{% translate "Create News" %}{% endif %}</h1>
+  <form method="POST" action="{% if entry.pk %}{% url "news-update" entry.slug %}{% else %}{% url "news-create" %}{% endif %}">
+  {% csrf_token %}
+  {{ form.as_div }}
+  <button type="submit" name="update">{% if entry.pk %}{% translate "Update" %}{% else %}{% translate "Create" %}{% endif %}</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
Part of #273, rebased onto https://github.com/cppalliance/temp-site/pull/356 and https://github.com/cppalliance/temp-site/pull/370 which should land first, isolating some of the moderation logic.