### PR TITLE
:pencil: Add options for skipping existing versions, passing API token

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -112,6 +112,8 @@ Here are the options you can use:
 - `--delete-versions`: Deletes all existing Version instances in the database before importing new ones.
 - `--delete-library-versions`: Deletes all existing LibraryVersion instances in the database before importing new ones.
 - `--create-recent-library-versions`: Creates a LibraryVersion for each active Boost library and the most recent Boost version.
+- `--skip-existing-versions`: If a Version exists in the database (by name), skip calling the GitHub API for more information on it.
+- `--token`: Pass a GitHub API token. If not passed, will use the value in `settings.GITHUB_TOKEN`.
 
 
 ### Example:

--- a/libraries/github.py
+++ b/libraries/github.py
@@ -29,6 +29,7 @@ class GithubAPIClient:
         owner: str = "boostorg",
         ref: str = "heads/master",
         repo_slug: str = "boost",
+        token: str = None,
     ) -> None:
         """
         Initialize the GitHubAPIClient.
@@ -37,7 +38,7 @@ class GithubAPIClient:
         :param ref: str, the Git reference
         :param repo_slug: str, the repository slug
         """
-        self.api = self.initialize_api()
+        self.api = self.initialize_api(token=token)
         self.owner = owner
         self.ref = ref
         self.repo_slug = repo_slug


### PR DESCRIPTION
Part of #168 

- Allows existing versions to be skipped when importing 
- Allows a GitHub API token to be passed to the management command (as a way to get around needing to set one for now, this will let me use mine in staging without setting it as the permanent value in staging) 