### PR TITLE
Add default ARGS value

### DIFF
--- a/justfile
+++ b/justfile
@@ -69,7 +69,7 @@ alias shell := console
 # ----
 
 # Compile new python dependencies
-@pip-compile:  ## rebuilds our pip requirements
+@pip-compile ARGS='':  ## rebuilds our pip requirements
     docker compose run --rm web pip-compile {{ ARGS }} ./requirements.in --output-file ./requirements.txt
 
 # Upgrade existing Python dependencies to their latest versions


### PR DESCRIPTION
@nessita When I pulled your changes to the `justfile` in, I got errors related to `ARGS`  when I ran `just shell`, `just test`, etc. Looks like it just needed a default value. 