### PR TITLE
Organize branch names

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: main
+    branches: develop
 
 env:
   DOCKER_BUILDKIT: "1"
@@ -69,7 +69,7 @@ jobs:
     needs: [test]
     name: Build and Publish Docker image
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
 
     steps:
       - name: Git - Get Sources


### PR DESCRIPTION
Boost generally follows a naming convention of "develop" and "master" branches. Let's switch to this.

- Create 'develop' branch as a copy of 'main'. 
- Create 'master' branch as a copy of 'main'. 
- Continue day-to-day development work in the 'develop' branch.
- Since boost.revsys.dev is a staging site it will use the code from 'develop'. 
- Every week or two, fast-forward merge 'develop' into 'master'. 

Let me know, if I should create the new git branches, or you can do that.
