### PR TITLE
Provide News creation and approval views.

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -32,7 +32,12 @@ from libraries.views import (
 )
 from libraries.api import LibrarySearchView
 from mailing_list.views import MailingListView, MailingListDetailView
-from news.views import EntryDetailView, EntryListView
+from news.views import (
+    EntryApproveView,
+    EntryCreateView,
+    EntryDetailView,
+    EntryListView,
+)
 from support.views import SupportView, ContactView
 from versions.api import VersionViewSet
 from versions.views import VersionList, VersionDetail
@@ -110,7 +115,11 @@ urlpatterns = (
         ),
         path("mailing-list/", MailingListView.as_view(), name="mailing-list"),
         path("news/", EntryListView.as_view(), name="news"),
+        path("news/add/", EntryCreateView.as_view(), name="news-create"),
         path("news/<slug:slug>/", EntryDetailView.as_view(), name="news-detail"),
+        path(
+            "news/<slug:slug>/approve/", EntryApproveView.as_view(), name="news-approve"
+        ),
         path(
             "people/detail/",
             TemplateView.as_view(template_name="boost/people_detail.html"),

--- a/news/forms.py
+++ b/news/forms.py
@@ -1,0 +1,8 @@
+from django import forms
+from .models import Entry
+
+
+class EntryForm(forms.ModelForm):
+    class Meta:
+        model = Entry
+        fields = ["title", "description"]

--- a/news/models.py
+++ b/news/models.py
@@ -76,7 +76,7 @@ class Entry(models.Model):
             raise self.AlreadyApprovedError()
         self.moderator = user
         self.approved_at = now()
-        self.save(update_fields=["moderator", "approved_at"])
+        self.save(update_fields=["moderator", "approved_at", "modified_at"])
 
     def save(self, *args, **kwargs):
         if not self.slug:
@@ -92,6 +92,9 @@ class Entry(models.Model):
             or user == self.author
             or (user is not None and user.has_perm("news.view_entry"))
         )
+
+    def can_approve(self, user):
+        return user is not None and user.has_perm("news.change_entry")
 
     def can_edit(self, user):
         return (not self.is_approved and user == self.author) or (

--- a/news/tests/test_forms.py
+++ b/news/tests/test_forms.py
@@ -1,0 +1,60 @@
+import datetime
+
+from django.utils.timezone import now
+from model_bakery import baker
+
+from ..forms import EntryForm
+from ..models import Entry
+
+
+def test_form_fields():
+    form = EntryForm()
+    assert sorted(form.fields.keys()) == ["description", "title"]
+
+
+def test_form_model_creates_entry(make_entry):
+    title = "The Title"
+    description = "Some description"
+    user = baker.make("users.User")
+    assert Entry.objects.filter(title=title).count() == 0
+
+    before = now()
+    form = EntryForm(instance=None, data={"title": title, "description": description})
+    assert form.is_valid()
+    form.instance.author = user
+    result = form.save()
+    after = now()
+
+    assert isinstance(result, Entry)
+    assert result.pk is not None
+    assert before <= result.created_at <= after
+    assert before <= result.modified_at <= after
+    assert before <= result.publish_at <= after
+    assert result.approved_at is None
+    assert result.title == title
+    assert result.description == description
+    assert result.author == user
+    assert result.moderator is None
+    assert Entry.objects.get(pk=result.pk) == result
+
+
+def test_form_model_modifies_entry(make_entry):
+    # Guard against runs that are too fast and this modified_at would not change
+    past = now() - datetime.timedelta(minutes=1)
+    news = make_entry(title="Old title", modified_at=past)
+    form = EntryForm(instance=news, data={"title": "New title"})
+    assert form.is_valid()
+
+    result = form.save()
+
+    # Modified fields
+    assert result.title == "New title"
+    assert result.modified_at > past
+    # Unchanged fields
+    assert result.pk == news.pk
+    assert result.created_at == news.created_at
+    assert result.approved_at == news.approved_at
+    assert result.publish_at == news.publish_at
+    assert result.description == news.description
+    assert result.author == news.author
+    assert result.moderator == news.moderator

--- a/news/tests/test_models.py
+++ b/news/tests/test_models.py
@@ -96,11 +96,13 @@ def test_entry_permissions_author(make_entry):
     assert entry.can_view(author) is True
     assert entry.can_edit(author) is True
     assert entry.can_delete(author) is False
+    assert entry.can_approve(author) is False
 
     entry.approve(baker.make("users.User"))
     assert entry.can_view(author) is True
     assert entry.can_edit(author) is False
     assert entry.can_delete(author) is False
+    assert entry.can_approve(author) is False
 
 
 def test_not_approved_entry_permissions_other_users(make_entry):
@@ -108,16 +110,19 @@ def test_not_approved_entry_permissions_other_users(make_entry):
     assert entry.can_view(None) is False
     assert entry.can_edit(None) is False
     assert entry.can_delete(None) is False
+    assert entry.can_approve(None) is False
 
     regular_user = baker.make("users.User")
     assert entry.can_view(regular_user) is False
     assert entry.can_edit(regular_user) is False
     assert entry.can_delete(regular_user) is False
+    assert entry.can_approve(regular_user) is False
 
     superuser = baker.make("users.User", is_superuser=True)
     assert entry.can_view(superuser) is True
     assert entry.can_edit(superuser) is True
     assert entry.can_delete(superuser) is True
+    assert entry.can_approve(superuser) is True
 
     user_with_add_perm = baker.make("users.User")
     user_with_add_perm.user_permissions.add(
@@ -126,6 +131,7 @@ def test_not_approved_entry_permissions_other_users(make_entry):
     assert entry.can_view(user_with_add_perm) is False
     assert entry.can_edit(user_with_add_perm) is False
     assert entry.can_delete(user_with_add_perm) is False
+    assert entry.can_approve(user_with_add_perm) is False
 
     user_with_change_perm = baker.make("users.User")
     user_with_change_perm.user_permissions.add(
@@ -134,6 +140,7 @@ def test_not_approved_entry_permissions_other_users(make_entry):
     assert entry.can_view(user_with_change_perm) is False
     assert entry.can_edit(user_with_change_perm) is True
     assert entry.can_delete(user_with_change_perm) is False
+    assert entry.can_approve(user_with_change_perm) is True
 
     user_with_delete_perm = baker.make("users.User")
     user_with_delete_perm.user_permissions.add(
@@ -142,6 +149,7 @@ def test_not_approved_entry_permissions_other_users(make_entry):
     assert entry.can_view(user_with_delete_perm) is False
     assert entry.can_edit(user_with_delete_perm) is False
     assert entry.can_delete(user_with_delete_perm) is True
+    assert entry.can_approve(user_with_delete_perm) is False
 
     user_with_view_perm = baker.make("users.User")
     user_with_view_perm.user_permissions.add(
@@ -150,6 +158,7 @@ def test_not_approved_entry_permissions_other_users(make_entry):
     assert entry.can_view(user_with_view_perm) is True
     assert entry.can_edit(user_with_view_perm) is False
     assert entry.can_delete(user_with_view_perm) is False
+    assert entry.can_approve(user_with_view_perm) is False
 
 
 def test_approved_entry_permissions_other_users(make_entry):
@@ -157,16 +166,19 @@ def test_approved_entry_permissions_other_users(make_entry):
     assert entry.can_view(None) is True
     assert entry.can_edit(None) is False
     assert entry.can_delete(None) is False
+    assert entry.can_approve(None) is False
 
     regular_user = baker.make("users.User")
     assert entry.can_view(regular_user) is True
     assert entry.can_edit(regular_user) is False
     assert entry.can_delete(regular_user) is False
+    assert entry.can_approve(regular_user) is False
 
     superuser = baker.make("users.User", is_superuser=True)
     assert entry.can_view(superuser) is True
     assert entry.can_edit(superuser) is True
     assert entry.can_delete(superuser) is True
+    assert entry.can_approve(superuser) is True
 
     user_with_add_perm = baker.make("users.User")
     user_with_add_perm.user_permissions.add(
@@ -175,6 +187,7 @@ def test_approved_entry_permissions_other_users(make_entry):
     assert entry.can_view(user_with_add_perm) is True
     assert entry.can_edit(user_with_add_perm) is False
     assert entry.can_delete(user_with_add_perm) is False
+    assert entry.can_approve(user_with_add_perm) is False
 
     user_with_change_perm = baker.make("users.User")
     user_with_change_perm.user_permissions.add(
@@ -183,6 +196,7 @@ def test_approved_entry_permissions_other_users(make_entry):
     assert entry.can_view(user_with_change_perm) is True
     assert entry.can_edit(user_with_change_perm) is True
     assert entry.can_delete(user_with_change_perm) is False
+    assert entry.can_approve(user_with_change_perm) is True
 
     user_with_delete_perm = baker.make("users.User")
     user_with_delete_perm.user_permissions.add(
@@ -191,6 +205,7 @@ def test_approved_entry_permissions_other_users(make_entry):
     assert entry.can_view(user_with_delete_perm) is True
     assert entry.can_edit(user_with_delete_perm) is False
     assert entry.can_delete(user_with_delete_perm) is True
+    assert entry.can_approve(user_with_delete_perm) is False
 
     user_with_view_perm = baker.make("users.User")
     user_with_view_perm.user_permissions.add(
@@ -199,6 +214,7 @@ def test_approved_entry_permissions_other_users(make_entry):
     assert entry.can_view(user_with_view_perm) is True
     assert entry.can_edit(user_with_view_perm) is False
     assert entry.can_delete(user_with_view_perm) is False
+    assert entry.can_approve(user_with_view_perm) is False
 
 
 def test_entry_manager_custom_queryset(make_entry):

--- a/news/tests/test_views.py
+++ b/news/tests/test_views.py
@@ -3,9 +3,12 @@ import datetime
 from django.utils.timezone import now
 from model_bakery import baker
 
+from ..forms import EntryForm
+from ..models import Entry
 
-def test_entry_list(tp, make_entry):
-    """List published news."""
+
+def test_entry_list(tp, make_entry, regular_user, authenticated=False):
+    """List published news for non authenticated users."""
     not_approved_news = make_entry(approved=False, title="needs moderation")
     yesterday_news = make_entry(
         approved=True, title="old news", publish_at=now() - datetime.timedelta(days=1)
@@ -18,6 +21,9 @@ def test_entry_list(tp, make_entry):
         title="future news",
         publish_at=now() + datetime.timedelta(days=1),
     )
+
+    if authenticated:
+        tp.login(regular_user)
 
     response = tp.get("news")
 
@@ -35,6 +41,13 @@ def test_entry_list(tp, make_entry):
     assert tomorrow_news.get_absolute_url() not in content
     assert tomorrow_news.title not in content
 
+    # If user is not authenticated, the Create News link should not be shown
+    assert (tp.reverse("news-create") in content) == authenticated
+
+
+def test_entry_list_authenticated(tp, make_entry, regular_user):
+    test_entry_list(tp, make_entry, regular_user, authenticated=True)
+
 
 def test_news_detail(tp, make_entry):
     """Browse details for a given news entry."""
@@ -48,6 +61,7 @@ def test_news_detail(tp, make_entry):
     content = str(response.content)
     assert news.title in content
     assert news.description in content
+    assert tp.reverse("news-approve", news.slug) not in content
 
     # no next nor prev links
     assert "newer entries" not in content.lower()
@@ -86,24 +100,145 @@ def test_news_detail_404(tp):
     tp.response_404(response)
 
 
-def test_news_detail_404_if_not_published(tp, make_entry):
+def test_news_detail_404_if_not_published(tp, make_entry, regular_user):
     """Details for a news entry are available if published or authored."""
     news = make_entry(published=False)
     response = tp.get(news.get_absolute_url())
     tp.response_404(response)
 
     # even if logged in, a regular user can not access the unpublished news
-    user = baker.make("users.User")
-    user.set_password("password")
-    user.save()
-    with tp.login(user):
+    with tp.login(regular_user):
         response = tp.get(news.get_absolute_url())
     tp.response_404(response)
 
     # but the entry author can access it even if unpublished
-    user = news.author
-    user.set_password("password")
-    user.save()
-    with tp.login(user):
+    with tp.login(news.author):
         response = tp.get(news.get_absolute_url())
     tp.response_200(response)
+
+
+def test_news_detail_actions_author(tp, make_entry):
+    """News entry is updatable by authors (if not approved)."""
+    news = make_entry(approved=False)  # not approved entry
+    with tp.login(news.author):
+        response = tp.get(news.get_absolute_url())
+    tp.response_200(response)
+
+    content = str(response.content)
+    assert tp.reverse("news-approve", news.slug) not in content
+
+    news.approve(baker.make("users.User"))
+    with tp.login(news.author):
+        response = tp.get(news.get_absolute_url())
+    tp.response_200(response)
+
+    content = str(response.content)
+    assert tp.reverse("news-approve", news.slug) not in content
+
+
+def test_news_detail_actions_moderator(tp, make_entry, moderator_user):
+    """Moderators can update, delete and approve a news entry."""
+    news = make_entry(approved=False)  # approved entry
+    with tp.login(moderator_user):
+        response = tp.get(news.get_absolute_url())
+    tp.response_200(response)
+
+    content = str(response.content)
+    assert tp.reverse("news-approve", news.slug) in content
+
+    news.approve(baker.make("users.User"))
+    with tp.login(moderator_user):
+        response = tp.get(news.get_absolute_url())
+    tp.response_200(response)
+
+    content = str(response.content)
+    assert tp.reverse("news-approve", news.slug) not in content
+
+
+def test_news_create_get(tp, regular_user):
+    url_name = "news-create"
+    # assertLoginRequired expects a non resolved URL, that is an URL name
+    # see https://github.com/revsys/django-test-plus/issues/202
+    tp.assertLoginRequired(url_name)
+
+    with tp.login(regular_user):
+        # assertGoodView expects a resolved URL
+        # see https://github.com/revsys/django-test-plus/issues/202
+        url = tp.reverse(url_name)
+        response = tp.assertGoodView(url, test_query_count=3, verbose=True)
+
+    form = tp.get_context("form")
+    assert isinstance(form, EntryForm)
+    for field in form:
+        tp.assertResponseContains(str(field), response)
+
+
+def test_news_create_post(tp, regular_user):
+    url = tp.reverse("news-create")
+    data = {
+        "title": "Lorem Ipsum",
+        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing.",
+    }
+    before = now()
+    with tp.login(regular_user):
+        response = tp.post(url, data=data, follow=True)
+    after = now()
+
+    entries = Entry.objects.filter(title=data["title"])
+    assert len(entries) == 1
+    entry = entries.get()
+    assert entry.slug == "lorem-ipsum"
+    assert entry.description == data["description"]
+    assert entry.author == regular_user
+    assert not entry.is_approved
+    assert not entry.is_published
+    # Avoid mocking `now()`, yet still ensure that the timestamps are
+    # between `before` and `after`
+    assert before <= entry.created_at <= after
+    assert before <= entry.modified_at <= after
+
+    tp.assertRedirects(response, entry.get_absolute_url())
+
+
+def test_news_approve_get_method_not_allowed(
+    tp, make_entry, regular_user, moderator_user
+):
+    entry = make_entry(approved=False)
+
+    # login is required
+    url_params = ("news-approve", entry.slug)
+    tp.assertLoginRequired(*url_params)
+
+    # regular users would get a 403
+    with tp.login(regular_user):
+        response = tp.get(*url_params)
+    tp.response_403(response)
+
+    # moderators users would get a 405 for GET
+    with tp.login(moderator_user):
+        response = tp.get(*url_params)
+    tp.response_405(response)
+
+
+def test_news_approve_post(tp, make_entry, regular_user, moderator_user):
+    entry = make_entry(approved=False)
+    url_params = ("news-approve", entry.slug)
+
+    # regular users would still get a 403 on POST
+    with tp.login(regular_user):
+        response = tp.post(*url_params)
+    tp.response_403(response)
+
+    # moderators users can POST to the view to approve an entry
+    with tp.login(moderator_user):
+        before = now()
+        response = tp.post(*url_params)
+        after = now()
+
+    tp.assertRedirects(response, entry.get_absolute_url())
+
+    entry.refresh_from_db()
+    assert entry.is_approved is True
+    assert entry.moderator == moderator_user
+    assert before <= entry.approved_at <= after
+    assert before <= entry.modified_at <= after

--- a/news/views.py
+++ b/news/views.py
@@ -1,8 +1,17 @@
-from django.http import Http404
-from django.views.generic import DetailView, ListView
-from django.utils.timezone import now
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.http import Http404, HttpResponseRedirect
+from django.utils.translation import gettext as _
+from django.views.generic import (
+    CreateView,
+    DetailView,
+    ListView,
+    View,
+)
+from django.views.generic.detail import SingleObjectMixin
 
 from .models import Entry
+from .forms import EntryForm
 
 
 def get_published_or_none(sibling_getter):
@@ -39,4 +48,36 @@ class EntryDetailView(DetailView):
         context = super().get_context_data(**kwargs)
         context["next"] = get_published_or_none(self.object.get_next_by_publish_at)
         context["prev"] = get_published_or_none(self.object.get_previous_by_publish_at)
+        context["user_can_approve"] = self.object.can_approve(self.request.user)
         return context
+
+
+class EntryCreateView(LoginRequiredMixin, CreateView):
+    model = Entry
+    form_class = EntryForm
+    template_name = "news/form.html"
+
+    def form_valid(self, form):
+        form.instance.author = self.request.user
+        return super().form_valid(form)
+
+
+class EntryApproveView(
+    LoginRequiredMixin, UserPassesTestMixin, SingleObjectMixin, View
+):
+    model = Entry
+    http_method_names = ["post"]
+
+    def test_func(self):
+        entry = self.get_object()
+        return entry.can_approve(self.request.user)
+
+    def post(self, request, *args, **kwargs):
+        entry = self.get_object()
+        try:
+            entry.approve(user=self.request.user)
+        except Entry.AlreadyApprovedError:
+            messages.error(request, _("The entry was already approved."))
+        else:
+            messages.success(request, _("The entry was successfully approved."))
+        return HttpResponseRedirect(entry.get_absolute_url())

--- a/templates/news/detail.html
+++ b/templates/news/detail.html
@@ -15,6 +15,21 @@
     <div class="py-16 md:mx-auto md:w-3/4">
       <h1 class="text-4xl">{{ entry.title }}</h1>
 
+      <!-- ACTIONS -->
+      <p>
+      {% if not entry.is_approved %}
+        {% if user_can_approve %}
+          <form method="POST" action="{% url 'news-approve' entry.slug %}">
+            {% csrf_token %}
+            <button type="submit" name="approve">{% translate "Approve" %}</button>
+          </form>
+        {% else %}
+          <strong>{% translate "Pending Moderation" %}</strong>
+        {% endif %}
+      {% endif %}
+      </p>
+      <!-- END ACTIONS -->
+
       <p class="mt-0 text-sm font-light">{{ entry.publish_at|date:"M jS, Y" }}</p>
 
       <p>{{ entry.description|linebreaks }}</p>

--- a/templates/news/form.html
+++ b/templates/news/form.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{% if entry.pk %}{% translate "Update News" %}{% else %}{% translate "Create News" %}{% endif %}</h1>
+  <form method="POST" action="{% if entry.pk %}{% url "news-update" entry.slug %}{% else %}{% url "news-create" %}{% endif %}">
+  {% csrf_token %}
+  {{ form.as_div }}
+  <button type="submit" name="update">{% if entry.pk %}{% translate "Update" %}{% else %}{% translate "Create" %}{% endif %}</button>
+</form>
+{% endblock %}

--- a/templates/news/list.html
+++ b/templates/news/list.html
@@ -60,6 +60,9 @@
 
       {% endif %}
       </div>
+      {% if entry_list and user.is_authenticated %}
+      <a href="{% url 'news-create' %}">{% translate "Create News" %}</a>
+      {% endif %}
 
     </div>
   </div>


### PR DESCRIPTION
More for #273: this branch provides a new form and view to create news (limited to authenticated users). For now, every new entry, requires moderation. Approval can be done via the web UI when visiting a news detail page and having the right permissions.

Next branch would provide:
* moderator whitelisting
* news list needing moderation view
* email sending on news submission