### PR TITLE
:sparkles: Add libraries by category view

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -25,6 +25,7 @@ from ak.views import (
 from core.views import MarkdownTemplateView, StaticContentTemplateView
 from libraries.views import (
     LibraryList,
+    LibraryListByCategory,
     LibraryDetail,
 )
 from libraries.api import LibrarySearchView
@@ -93,6 +94,11 @@ urlpatterns = (
             "donate/",
             TemplateView.as_view(template_name="donate/donate.html"),
             name="donate",
+        ),
+        path(
+            "libraries/by-category/",
+            LibraryListByCategory.as_view(),
+            name="libraries-by-category",
         ),
         path("libraries/", LibraryList.as_view(), name="libraries"),
         path(

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -1,5 +1,4 @@
 import datetime
-import pytest
 
 from model_bakery import baker
 
@@ -36,13 +35,13 @@ def test_library_list_no_pagination(library_version, tp):
     library_list = res.context.get("library_list")
     assert library_list is not None
     assert len(library_list) == len(libs)
-    assert all(l in library_list for l in libs)
+    assert all(library in library_list for library in libs)
     page_obj = res.context.get("page_obj")
     assert getattr(page_obj, "paginator", None) is None
 
 
 def test_library_list_select_category(library_version, category, tp):
-    """GET /libraries/?category={{ slug }} to submit a category loads the filtered results"""
+    """GET /libraries/?category={{ slug }} loads filtered results"""
     library_version.library.categories.add(category)
     # Create a new library version that is not in the selected category
     new_lib_version = baker.make(
@@ -55,7 +54,7 @@ def test_library_list_select_category(library_version, category, tp):
 
 
 def test_library_list_select_version(library_version, tp):
-    """GET /libraries/?version={{ slug }} to submit a version loads the filtered results"""
+    """GET /libraries/?version={{ slug }} loads filtered results"""
     new_version = baker.make("versions.Version")
     # Create a new library version that is not in the selected version
     new_lib_version = baker.make("libraries.LibraryVersion", version=new_version)
@@ -63,6 +62,16 @@ def test_library_list_select_version(library_version, tp):
     tp.response_200(res)
     assert library_version.library in res.context["library_list"]
     assert new_lib_version.library not in res.context["library_list"]
+
+
+def test_library_list_by_category(library_version, category, tp):
+    """GET /libraries/by-category/"""
+    library_version.library.categories.add(category)
+    res = tp.get("libraries-by-category")
+    tp.response_200(res)
+    assert "library_list" in res.context
+    assert "category" in res.context["library_list"][0]
+    assert "libraries" in res.context["library_list"][0]
 
 
 def test_library_detail(library_version, tp):

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -59,6 +59,30 @@ class LibraryList(CategoryMixin, ListView):
         return context
 
 
+class LibraryListByCategory(LibraryList):
+    """List all Boost libraries sorted by Category."""
+
+    template_name = "libraries/list.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["by_category"] = True
+        context["library_list"] = self.get_results_by_category()
+        return context
+
+    def get_results_by_category(self):
+        queryset = super().get_queryset()
+        results_by_category = []
+        for category in Category.objects.all().order_by("name"):
+            results_by_category.append(
+                {
+                    "category": category,
+                    "libraries": queryset.filter(categories=category).order_by("name"),
+                }
+            )
+        return results_by_category
+
+
 class LibraryDetail(CategoryMixin, FormMixin, DetailView):
     """Display a single Library in insolation"""
 

--- a/templates/libraries/list.html
+++ b/templates/libraries/list.html
@@ -72,9 +72,18 @@
 
   <!-- Libraries list -->
   <div class="grid grid-cols-1 gap-4 mb-5 md:grid-cols-2 xl:grid-cols-3">
-    {% for library in library_list %}
-      {% include "libraries/_library_list_item.html" %}
-    {% endfor %}
+    {% if by_category %}
+      {% for result in library_list %}
+        <h2>{{ result.category }}</h2>
+        {% for library in result.libraries %}
+          {% include "libraries/_library_list_item.html" %}
+        {% endfor %}
+      {% endfor %}
+    {% else %}
+      {% for library in library_list %}
+        {% include "libraries/_library_list_item.html" %}
+      {% endfor %}
+    {% endif %}
   </div>
   <!-- end libraries list -->
 


### PR DESCRIPTION
- Adds `/libraries/by-category`
- Uses the same template `list.html` as the existing list view. @gregnewman when you have a custom template, though, you can replace `libraries.views.LibraryListByCategory.template_name`. In the meantime, there is a template var `by_category` that you can key off of. 

The sorting is ugly but present 😬 

<img width="1071" alt="Screenshot 2023-05-23 at 12 21 08 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/e9921995-aa47-4be2-bc5e-ea47422271b2">
