### PR TITLE
Mini library views

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -25,7 +25,9 @@ from ak.views import (
 from core.views import MarkdownTemplateView, StaticContentTemplateView
 from libraries.views import (
     LibraryList,
+    LibraryListMini,
     LibraryListByCategory,
+    LibraryListByCategoryMini,
     LibraryDetail,
 )
 from libraries.api import LibrarySearchView
@@ -96,10 +98,16 @@ urlpatterns = (
             name="donate",
         ),
         path(
+            "libraries/by-category/mini/",
+            LibraryListByCategoryMini.as_view(),
+            name="libraries-by-category-mini",
+        ),
+        path(
             "libraries/by-category/",
             LibraryListByCategory.as_view(),
             name="libraries-by-category",
         ),
+        path("libraries/mini/", LibraryListMini.as_view(), name="libraries-mini"),
         path("libraries/", LibraryList.as_view(), name="libraries"),
         path(
             "libraries/<slug:slug>/",

--- a/config/urls.py
+++ b/config/urls.py
@@ -25,6 +25,7 @@ from ak.views import (
 from core.views import MarkdownTemplateView, StaticContentTemplateView
 from libraries.views import (
     LibraryList,
+    LibraryListByCategory,
     LibraryDetail,
 )
 from libraries.api import LibrarySearchView
@@ -93,6 +94,11 @@ urlpatterns = (
             "donate/",
             TemplateView.as_view(template_name="donate/donate.html"),
             name="donate",
+        ),
+        path(
+            "libraries/by-category/",
+            LibraryListByCategory.as_view(),
+            name="libraries-by-category",
         ),
         path("libraries/", LibraryList.as_view(), name="libraries"),
         path(

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -3,7 +3,7 @@ import datetime
 from model_bakery import baker
 
 
-def test_library_list(library_version, tp):
+def test_library_list(library_version, tp, url_name="libraries"):
     """GET /libraries/"""
     last_year = datetime.date.today() - datetime.timedelta(days=365)
     v2 = baker.make("versions.Version", name="Version 1.78.0", release_date=last_year)
@@ -12,11 +12,16 @@ def test_library_list(library_version, tp):
         name="sample",
     )
     baker.make("libraries.LibraryVersion", library=lib2, version=v2)
-    res = tp.get("libraries")
+    res = tp.get(url_name)
     tp.response_200(res)
     assert "library_list" in res.context
     assert library_version.library in res.context["library_list"]
     assert lib2 not in res.context["library_list"]
+
+
+def test_library_list_mini(library_version, tp):
+    """GET /libraries/mini/"""
+    test_library_list(library_version, tp, url_name="libraries-mini")
 
 
 def test_library_list_no_pagination(library_version, tp):
@@ -64,14 +69,23 @@ def test_library_list_select_version(library_version, tp):
     assert new_lib_version.library not in res.context["library_list"]
 
 
-def test_library_list_by_category(library_version, category, tp):
+def test_library_list_by_category(
+    library_version, category, tp, url="libraries-by-category"
+):
     """GET /libraries/by-category/"""
     library_version.library.categories.add(category)
-    res = tp.get("libraries-by-category")
+    res = tp.get(url)
     tp.response_200(res)
     assert "library_list" in res.context
     assert "category" in res.context["library_list"][0]
     assert "libraries" in res.context["library_list"][0]
+
+
+def test_library_list_by_category_mini(library_version, category, tp):
+    """GET /libraries/by-category/mini/"""
+    test_library_list_by_category(
+        library_version, category, tp, url="libraries-by-category-mini"
+    )
 
 
 def test_library_detail(library_version, tp):

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -1,5 +1,4 @@
 import datetime
-import pytest
 
 from model_bakery import baker
 
@@ -36,13 +35,13 @@ def test_library_list_no_pagination(library_version, tp):
     library_list = res.context.get("library_list")
     assert library_list is not None
     assert len(library_list) == len(libs)
-    assert all(l in library_list for l in libs)
+    assert all(library in library_list for library in libs)
     page_obj = res.context.get("page_obj")
     assert getattr(page_obj, "paginator", None) is None
 
 
 def test_library_list_select_category(library_version, category, tp):
-    """GET /libraries/?category={{ slug }} to submit a category loads the filtered results"""
+    """GET /libraries/?category={{ slug }} loads filtered results"""
     library_version.library.categories.add(category)
     # Create a new library version that is not in the selected category
     new_lib_version = baker.make(
@@ -55,7 +54,7 @@ def test_library_list_select_category(library_version, category, tp):
 
 
 def test_library_list_select_version(library_version, tp):
-    """GET /libraries/?version={{ slug }} to submit a version loads the filtered results"""
+    """GET /libraries/?version={{ slug }} loads filtered results"""
     new_version = baker.make("versions.Version")
     # Create a new library version that is not in the selected version
     new_lib_version = baker.make("libraries.LibraryVersion", version=new_version)
@@ -63,6 +62,16 @@ def test_library_list_select_version(library_version, tp):
     tp.response_200(res)
     assert library_version.library in res.context["library_list"]
     assert new_lib_version.library not in res.context["library_list"]
+
+
+def test_library_list_by_category(library_version, category, tp):
+    """GET /libraries/by-category/"""
+    library_version.library.categories.add(category)
+    res = tp.get("libraries-by-category")
+    tp.response_200(res)
+    assert "library_list" in res.context
+    assert "category" in res.context["library_list"][0]
+    assert "libraries" in res.context["library_list"][0]
 
 
 def test_library_detail(library_version, tp):

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -59,6 +59,30 @@ class LibraryList(CategoryMixin, ListView):
         return context
 
 
+class LibraryListByCategory(LibraryList):
+    """List all Boost libraries sorted by Category."""
+
+    template_name = "libraries/list.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["by_category"] = True
+        context["library_list"] = self.get_results_by_category()
+        return context
+
+    def get_results_by_category(self):
+        queryset = super().get_queryset()
+        results_by_category = []
+        for category in Category.objects.all().order_by("name"):
+            results_by_category.append(
+                {
+                    "category": category,
+                    "libraries": queryset.filter(categories=category).order_by("name"),
+                }
+            )
+        return results_by_category
+
+
 class LibraryDetail(CategoryMixin, FormMixin, DetailView):
     """Display a single Library in insolation"""
 

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -59,6 +59,12 @@ class LibraryList(CategoryMixin, ListView):
         return context
 
 
+class LibraryListMini(LibraryList):
+    """Flat list version of LibraryList"""
+
+    template_name = "libraries/list.html"
+
+
 class LibraryListByCategory(LibraryList):
     """List all Boost libraries sorted by Category."""
 
@@ -81,6 +87,12 @@ class LibraryListByCategory(LibraryList):
                 }
             )
         return results_by_category
+
+
+class LibraryListByCategoryMini(LibraryListByCategory):
+    """Flat list version of LibraryListByCategory"""
+
+    template_name = "libraries/list.html"
 
 
 class LibraryDetail(CategoryMixin, FormMixin, DetailView):

--- a/templates/libraries/list.html
+++ b/templates/libraries/list.html
@@ -72,9 +72,18 @@
 
   <!-- Libraries list -->
   <div class="grid grid-cols-1 gap-4 mb-5 md:grid-cols-2 xl:grid-cols-3">
-    {% for library in library_list %}
-      {% include "libraries/_library_list_item.html" %}
-    {% endfor %}
+    {% if by_category %}
+      {% for result in library_list %}
+        <h2>{{ result.category }}</h2>
+        {% for library in result.libraries %}
+          {% include "libraries/_library_list_item.html" %}
+        {% endfor %}
+      {% endfor %}
+    {% else %}
+      {% for library in library_list %}
+        {% include "libraries/_library_list_item.html" %}
+      {% endfor %}
+    {% endif %}
   </div>
   <!-- end libraries list -->
 


### PR DESCRIPTION
- Add `/libraries/mini/` and `/libraries/by-category/mini/` 
- @gregnewman both of these are ultimately just subclasses of `libraries.views.LibraryList`, so the category and version filtering should still work if you need it. The form action for the filtering is manually set to `/libraries/` and I didn't change it yet -- will these pages also need the same version and category filtering as the others? If so, I'll make a new PR that corrects the form action so the filtering will work on all versions of the page. 
- When you're ready for the custom template, replace the `template_name` in `LibraryListMini` and `LibraryListByCategoryMini` with the path to your template. Object names should be the same as in `list.html`. 