### PR TITLE
Update dependencies, including security release of requests

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -34,7 +34,7 @@ redis==4.5.4
 # Testing
 black==22.3
 django-bakery
-django-test-plus
+git+https://github.com/revsys/django-test-plus.git#egg=django-test-plus
 pytest
 pytest-cov
 pytest-django
@@ -58,4 +58,4 @@ django-mptt==0.14
 
 # Github
 ghapi
-requests==2.28.2
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ amqp==5.1.1
     # via kombu
 appdirs==1.4.4
     # via fs
-asgiref==3.6.0
+asgiref==3.7.0
     # via django
 asttokens==2.2.1
     # via stack-data
@@ -20,11 +20,11 @@ billiard==3.6.4.0
     # via celery
 black==22.3
     # via -r ./requirements.in
-boto3==1.26.135
+boto3==1.26.139
     # via
     #   -r ./requirements.in
     #   django-bakery
-botocore==1.29.135
+botocore==1.29.139
     # via
     #   boto3
     #   s3transfer
@@ -59,7 +59,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-coverage[toml]==7.2.5
+coverage[toml]==7.2.6
     # via pytest-cov
 cryptography==40.0.2
     # via
@@ -123,7 +123,7 @@ django-rest-auth==0.9.5
     # via -r ./requirements.in
 django-storages==1.13.2
     # via -r ./requirements.in
-django-test-plus==2.2.1
+django-test-plus @ git+https://github.com/revsys/django-test-plus.git
     # via -r ./requirements.in
 django-tracer==0.9.3
     # via -r ./requirements.in
@@ -175,7 +175,7 @@ marshmallow==3.19.0
     # via environs
 matplotlib-inline==0.1.6
     # via ipython
-minio==7.1.14
+minio==7.1.15
     # via -r ./requirements.in
 mistletoe==1.0.1
     # via -r ./requirements.in
@@ -263,7 +263,7 @@ redis==4.5.4
     # via
     #   -r ./requirements.in
     #   django-redis
-requests==2.28.2
+requests==2.31.0
     # via
     #   -r ./requirements.in
     #   django-allauth
@@ -292,11 +292,11 @@ traitlets==5.9.0
     # via
     #   ipython
     #   matplotlib-inline
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.10
     # via responses
-typing-extensions==4.5.0
+typing-extensions==4.6.0
     # via dj-database-url
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   botocore
     #   minio


### PR DESCRIPTION
Following the dependabot notice https://github.com/cppalliance/temp-site/security/dependabot/37, I ran `just pip-compile --upgrade`. I took the opportunity to upgrade `django-test-plus` to latest `main` to be able to use latest features and fixes.