### PR TITLE
Strip footer from asciidoc content (Part of #394)

### DIFF
--- a/core/boostrenderer.py
+++ b/core/boostrenderer.py
@@ -1,6 +1,6 @@
 import boto3
 from botocore.exceptions import ClientError
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 import json
 import os
 import re
@@ -23,7 +23,7 @@ def get_body_from_html(html_string: str) -> str:
     the <body> tag.
 
     We strip out the <body> tag because we want to use our main Boost template,
-    which includes its own <body> tag.
+    which includes its own <body> tag. Skip any tag with an id containing 'footer'.
 
     Args:
         html_string (str): The HTML document as a string
@@ -35,7 +35,12 @@ def get_body_from_html(html_string: str) -> str:
     body = soup.find("body")
     body_content = ""
     if body:
-        body_content = "".join(str(tag) for tag in body.contents)
+        body_content = "".join(
+            str(tag)
+            for tag in body.contents
+            if isinstance(tag, Tag)
+            and not (tag.get("id") and "footer" in tag.get("id"))
+        )
     return body_content
 
 

--- a/core/tests/test_renderer.py
+++ b/core/tests/test_renderer.py
@@ -9,6 +9,21 @@ def test_get_body_from_html():
     assert body_content == "<h1>Test</h1>"
 
 
+def test_get_body_from_html_strip_footer():
+    html_string = """
+    <html>
+        <head><title>Test</title></head>
+        <body>
+            <h1>Test</h1>
+            <div id='footer'>Some content</div>
+            <span id='contains-footer'>More content</span>
+        </body>
+    </html>
+    """
+    body_content = get_body_from_html(html_string)
+    assert body_content == "<h1>Test</h1>"
+
+
 def test_get_content_type():
     # HTML file content type is text/html
     assert get_content_type("/marshmallow/index.html", "text/html"), "text/html"


### PR DESCRIPTION
Part of #394 

- Strips any tags with "footer" in them from the content that gets rendered. The data isn't meaningful -- it reflects the last time the content was converted to html, not the last time the file was actually updated. 

Before: 
<img width="633" alt="Screenshot 2023-06-07 at 2 09 09 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/94f3373e-b1ba-4e3d-bee2-3abfe05ab152">

After: 
<img width="618" alt="Screenshot 2023-06-07 at 2 04 30 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/c80b911b-489a-472e-893e-617e57141b6c">
