### PR TITLE
#252/#394 Render adoc content in library details page 

### DIFF
--- a/libraries/github.py
+++ b/libraries/github.py
@@ -230,6 +230,32 @@ class GithubAPIClient:
         else:
             return response.json()
 
+    def get_file_content(
+        self,
+        repo_slug: str = None,
+        tag: str = "master",
+        file_path: str = "library-detail.adoc",
+    ) -> str:
+        """
+        Get the specified file for the repo from the GitHub API, if it exists.
+
+        :param repo_slug: str, the repository slug
+        :param tag: str, the Git tag
+        :param file_name: str, the name of the file to fetch. Should be "library-detail.adoc" or "README.md".
+        :return: str, the specified file content from the repo
+        """
+        url = f"https://raw.githubusercontent.com/{self.owner}/{repo_slug}/{tag}/{file_path}"  # noqa
+
+        response = requests.get(url)
+
+        if not response.status_code == 200:
+            logger.exception(
+                "get_file_content_failed", repo=repo_slug, url=url, file=file_path
+            )
+            return None
+
+        return response.content
+
     def get_ref(self, repo_slug: str = None, ref: str = None) -> dict:
         """
         Get the ref from the GitHub API.

--- a/libraries/tests/test_utils.py
+++ b/libraries/tests/test_utils.py
@@ -1,6 +1,21 @@
 from datetime import datetime
+import os
 
-from libraries.utils import generate_fake_email, parse_date
+from libraries.utils import (
+    decode_content,
+    generate_fake_email,
+    parse_date,
+    write_content_to_tempfile,
+)
+
+
+def test_decode_content():
+    byte_content = b"This is a test content"
+    str_content = "This is a test content"
+    decoded_byte_content = decode_content(byte_content)
+    decoded_str_content = decode_content(str_content)
+    assert decoded_byte_content == str_content
+    assert decoded_str_content == str_content
 
 
 def test_generate_fake_email():
@@ -28,3 +43,13 @@ def test_parse_date_str_none():
     expected = None
     result = parse_date("")
     assert expected == result
+
+
+def test_write_content_to_tempfile():
+    content = b"This is a test content"
+    temp_file = write_content_to_tempfile(content)
+    assert os.path.exists(temp_file.name)
+    with open(temp_file.name, "rb") as f:
+        file_content = f.read()
+    assert file_content == content
+    os.remove(temp_file.name)

--- a/libraries/utils.py
+++ b/libraries/utils.py
@@ -1,10 +1,18 @@
 import structlog
+import tempfile
 
 from dateutil.parser import ParserError, parse
 from django.utils.text import slugify
 
 
 logger = structlog.get_logger()
+
+
+def decode_content(content):
+    """Decode bytes to string."""
+    if isinstance(content, bytes):
+        return content.decode("utf-8")
+    return content
 
 
 def generate_fake_email(val: str) -> str:
@@ -25,3 +33,14 @@ def parse_date(date_str):
     except ParserError:
         logger.info("parse_date_invalid_date", date_str=date_str)
         return None
+
+
+def write_content_to_tempfile(content):
+    """Accepts string or bytes content, writes it to a temporary file, and returns the
+    file object."""
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        if isinstance(content, bytes):
+            temp_file = open(temp_file.name, "wb")
+        temp_file.write(content)
+        temp_file.close()
+    return temp_file

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -7,6 +7,7 @@ from django.views.generic.edit import FormMixin
 
 from versions.models import Version
 from .forms import VersionSelectionForm
+from .github import GithubAPIClient
 from .models import Category, Issue, Library, LibraryVersion, PullRequest
 
 logger = structlog.get_logger()
@@ -114,6 +115,10 @@ class LibraryDetail(CategoryMixin, FormMixin, DetailView):
             .filter(library_version__library=self.object)
             .distinct()
             .order_by("-release_date")
+        )
+        client = GithubAPIClient(repo_slug=self.object.github_repo)
+        context["description"] = self.object.get_description(
+            client, tag=context["version"].name
         )
         return context
 

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -90,17 +90,9 @@
         </div>
 
 
-        <div class="p-4 my-4 bg-white rounded-lg dark:bg-charcoal">
-          <h3>Introduction</h3>
-
-          <p>Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec id elit non mi porta gravida at eget metus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
-
-          <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Nulla vitae elit libero, a pharetra augue. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas faucibus mollis interdum.</p>
-
-          <p>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Donec id elit non mi porta gravida at eget metus. Donec ullamcorper nulla non metus auctor fringilla. Maecenas faucibus mollis interdum. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.</p>
-
-          <p>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Cras mattis consectetur purus sit amet fermentum. Donec sed odio dui.</p>
-        </div>
+        {% if description %}<div class="p-4 my-4 bg-white rounded-lg dark:bg-charcoal">
+          {{ description|safe }}
+        </div>{% endif %}
       </div>
       <!-- end overview -->
     </div>


### PR DESCRIPTION
Part of #252 and #394

In this PR: 

- [x] Retrieve library adoc description from Github
- [x] Fallback to README if there is no adoc content 
- [x] Fail gracefully if the content isn't present 
- [x] Render the content safely in the template   
- [x] Retrieve the right version of the adoc or README file if on a specific version 
- [x] Cache the description content in a version-specific way to Redis and the db and retrieve from cache when possible 

Confirmed in a live test that this passes these tests: 

- content from an adoc on `develop` (JSON library)
- content from an adoc file on a specific release (JSON library)
- content from a README for a specific release (Assign library)
- blank description when there is no readme and no adoc file (Bimap library) 
- content from a README for an older release when a newer release uses adoc (JSON older version)

Once approved, I'll rebase so the commits are pretty. 

## In a future PR: 

Kicking off a task to update the description when on a non-released tag (so when on `master` or `develop`). This is different from similar logic in #394 that checks the updated date for the adoc file every time we hit the database, to see if it needs to be updated. In this case, if we are on a specific release, the data in GitHub shouldn't change, so I would think we should be good to store it once in the db and then use it forever/until we need to bust the database cache?  


