### PR TITLE
#252 Show the link to the right version of a library's docs on the detail page 

### DIFF
--- a/libraries/models.py
+++ b/libraries/models.py
@@ -264,6 +264,17 @@ class LibraryVersion(models.Model):
         return f"{self.library.name} ({self.version.name})"
 
     @cached_property
+    def documentation_url(self):
+        """
+        format: https://www.boost.org/doc/libs/1_82_0/libs/bimap/
+
+        Use the `key` field and NOT the `slug` field due to special cases --
+        submodules like Functional/Factory
+        """
+        url = f"https://www.boost.org/doc/libs/{self.version.boost_url_slug}/libs/{self.library.key}/"
+        return url
+
+    @cached_property
     def library_repo_url_for_version(self):
         """Returns the URL to the GitHub repository for the library at this specicfic
         version.

--- a/libraries/tests/test_models.py
+++ b/libraries/tests/test_models.py
@@ -106,3 +106,13 @@ def test_library_repo_url_for_version_invalid_data(library_version):
 
     with pytest.raises(ValueError):
         library_version.library_repo_url_for_version
+        
+def test_library_version_documentation_url(library_version):
+    library_version.version.slug = "boost-1.82.0"
+    library_version.version.save()
+    version = library_version.version
+    library = library_version.library
+    version_slug = version.boost_url_slug
+    lib_slug = library.key
+    expected = f"https://www.boost.org/doc/libs/{version_slug}/libs/{lib_slug}/"
+    assert library_version.documentation_url == expected

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -106,6 +106,7 @@ class LibraryDetail(CategoryMixin, FormMixin, DetailView):
     def get_context_data(self, **kwargs):
         """Set the form action to the main libraries page"""
         context = super().get_context_data(**kwargs)
+        context["documentation_url"] = self.get_documentation_url()
         context["version"] = self.get_version()
         context["maintainers"] = self.get_maintainers(context["version"])
         context["versions"] = (
@@ -138,6 +139,21 @@ class LibraryDetail(CategoryMixin, FormMixin, DetailView):
         except self.model.DoesNotExist:
             raise Http404("No library found matching the query")
         return obj
+
+    def get_documentation_url(self):
+        """Return the URL for the link to the external Boost documentation."""
+        obj = self.get_object()
+        version = self.get_version()
+        try:
+            library_version = LibraryVersion.objects.get(library=obj, version=version)
+            return library_version.documentation_url
+        except LibraryVersion.DoesNotExist:
+            logger.exception(
+                "library_detail_view_library_version_does_not_exist",
+                library_slug=obj.slug,
+                version_slug=version.slug,
+            )
+            return None
 
     def get_github_url(self, version):
         """Get the GitHub URL for the current library."""

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -42,10 +42,10 @@
 
         <div class="p-4 md:flex md:space-x-3">
           <div class="px-2 pt-2 space-y-2 w-full bg-white rounded-lg md:w-1/3 dark:bg-charcoal">
-              <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100" href="https://boost.org/libs/{{ object.slug }}">
+              <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100" href="{{ documentation_url }}">
                 <i class="float-right mt-3 fas fa-folder"></i>
                 Documentation
-                <span class="block text-xs text-sky-600">boost.org/libs/{{ object.slug }}</span>
+                <span class="block text-xs text-sky-600">boost.org/libs/{{ object.key }}</span>
               </a>
               <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100" href="{{ object.github_issues_url }}">
                 <i class="float-right mt-3 fas fa-bug"></i>

--- a/versions/models.py
+++ b/versions/models.py
@@ -45,6 +45,25 @@ class Version(models.Model):
     def display_name(self):
         return self.name.replace("boost-", "")
 
+    @cached_property
+    def boost_url_slug(self):
+        """Return the slug for the version that is used in the Boost URL to get to
+        the existing Boost docs. The GitHub slug and the Boost slug don't match, so
+        this method converts the GitHub slug to the Boost slug.
+
+        Example:
+        - "boost-1.75.0" --> "1_75_0"
+        - "develop" --> "develop"
+        """
+        # A Boost release, formmatted as "boost-N.NN.N"
+        if "-" in self.slug:
+            slug_parts = self.slug.split("-")[1:]
+            formatted_slug = "_".join(slug_parts)
+        # A specific tag, like "develop"
+        else:
+            formatted_slug = self.slug
+        return formatted_slug
+
 
 class VersionFile(models.Model):
     Unix = "Unix"

--- a/versions/tests/test_models.py
+++ b/versions/tests/test_models.py
@@ -1,4 +1,5 @@
 import datetime
+import pytest
 
 from model_bakery import baker
 
@@ -17,12 +18,25 @@ def test_version_slug(version):
     assert version.slug == "new-name"
 
 
+@pytest.mark.parametrize(
+    "slug, expected_slug",
+    [
+        ("boost-1.71.0", "1_71_0"),
+        ("boost-1-71-0", "1_71_0"),
+        ("develop", "develop"),
+    ],
+)
+def test_boost_url_slug(slug, expected_slug):
+    version = baker.make("versions.Version", name=slug)
+    assert version.boost_url_slug == expected_slug
+
+
 def test_version_get_slug(db):
     version = baker.prepare("versions.Version", name="Sample Library")
     assert version.get_slug() == "sample-library"
 
 
-def test_version_display_bname(version):
+def test_version_display_name(version):
     version.name = "boost-1.81.0"
     version.save()
     assert version.display_name == "1.81.0"


### PR DESCRIPTION
- Adds method to the `LibraryVersion` model to generate a link to `https://www.boost.org/doc/libs/{release}/libs/{lib_path}/` (which will redirect appropriately, example: https://www.boost.org/doc/libs/1_71_0/libs/functional/factory/doc/html/index.html) 
- Tested on multiple versions of multiple libraries, including sub-libraries like "Functional/Factory" 

Part of #252 