### PR TITLE
#252 Link to versioned  library github page

### DIFF
--- a/libraries/models.py
+++ b/libraries/models.py
@@ -263,6 +263,16 @@ class LibraryVersion(models.Model):
     def __str__(self):
         return f"{self.library.name} ({self.version.name})"
 
+    @cached_property
+    def library_repo_url_for_version(self):
+        """Returns the URL to the GitHub repository for the library at this specicfic
+        version.
+        """
+        if not self.library or not self.version or not self.library.github_url:
+            raise ValueError("Invalid data for library version")
+
+        return f"{self.library.github_url}/tree/{self.version.name}"
+
 
 class Issue(models.Model):
     """

--- a/libraries/tests/test_models.py
+++ b/libraries/tests/test_models.py
@@ -1,3 +1,4 @@
+import pytest
 from model_bakery import baker
 
 
@@ -72,3 +73,36 @@ def test_library_version_multiple_versions(library, library_version):
         library_version__version=library_version.version
     ).exists()
     assert library.versions.filter(library_version__version=other_version).exists()
+
+
+def test_library_repo_url_for_version(library_version):
+    result = library_version.library_repo_url_for_version
+    expected_url = (
+        f"{library_version.library.github_url}/tree/{library_version.version.name}"
+    )
+    assert result == expected_url
+
+
+def test_library_repo_url_for_version_invalid_data(library_version):
+    version = library_version.version
+    library = library_version.library
+
+    library_version.version = None
+    library_version.save()
+
+    with pytest.raises(ValueError):
+        library_version.library_repo_url_for_version
+
+    library_version.version = version
+    library_version.library = None
+    library_version.save()
+
+    with pytest.raises(ValueError):
+        library_version.library_repo_url_for_version
+
+    library_version.library = library
+    library_version.library.github_url = None
+    library_version.library.save()
+
+    with pytest.raises(ValueError):
+        library_version.library_repo_url_for_version

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -118,6 +118,7 @@ class LibraryDetail(CategoryMixin, FormMixin, DetailView):
         context["description"] = self.object.get_description(
             client, tag=context["version"].name
         )
+        context["github_url"] = self.get_github_url(context["version"])
         return context
 
     def get_object(self):
@@ -137,6 +138,17 @@ class LibraryDetail(CategoryMixin, FormMixin, DetailView):
         except self.model.DoesNotExist:
             raise Http404("No library found matching the query")
         return obj
+
+    def get_github_url(self, version):
+        """Get the GitHub URL for the current library."""
+        try:
+            library_version = LibraryVersion.objects.get(
+                library=self.object, version=version
+            )
+            return library_version.library_repo_url_for_version
+        except LibraryVersion.DoesNotExist:
+            # This should never happen because it should be caught in get_object
+            return self.object.github_url
 
     def get_maintainers(self, version):
         """Get the maintainers for the current LibraryVersion."""

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -52,10 +52,10 @@
                 GitHub Issues
                 <span class="block text-xs text-sky-600">{{ object.github_issues_url|cut:"https://" }}</span>
               </a>
-              <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100" href="{{ object.github_url }}">
+              <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100" href="{{ github_url }}">
                 <i class="float-right mt-3 fab fa-github"></i>
                 Source Code
-                <span class="block text-xs text-sky-600">{{ object.github_url|cut:"https://" }}</span>
+                <span class="block text-xs text-sky-600">{{ github_url|cut:"https://" }}</span>
               </a>
 
               <div class="inline-block py-1 px-2 w-full rounded cursor-pointer hover:bg-gray-100">


### PR DESCRIPTION
Part of #252 Making all the links on the library detail page specific to the Boost release.  

@vinniefalco Quick question -- Did you want the visible URL to just show the general link to the repo, but the actual link to go to the version'd github link? Or should the link display make it clear which version they're going to? Example: 
<img width="897" alt="Screenshot 2023-06-15 at 3 47 58 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/3a8f4363-0b46-40be-8b06-6aeb6866d23a">

versus 

<img width="898" alt="Screenshot 2023-06-15 at 3 49 38 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/965686cc-8a01-430f-b13c-81cd658febd9">
