### PR TITLE
Remove open PR and Issue counts

### DIFF
--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -109,25 +109,6 @@ def test_library_detail_404(library, tp):
     tp.response_404(response)
 
 
-def test_library_detail_context_get_closed_prs_count(tp, library_version):
-    """
-    GET /libraries/{slug}/
-    Test that the custom closed_prs_count var appears as expected
-    """
-    library = library_version.library
-    # Create open and closed PRs for this library, and another random PR
-    lib2 = baker.make("libraries.Library", slug="sample")
-    baker.make("libraries.PullRequest", library=library, is_open=True)
-    baker.make("libraries.PullRequest", library=library, is_open=False)
-    baker.make("libraries.PullRequest", library=lib2, is_open=True)
-    url = tp.reverse("library-detail", library.slug)
-    response = tp.get(url)
-    tp.response_200(response)
-    assert "closed_prs_count" in response.context
-    # Verify that the count only includes the one open PR for this library
-    assert response.context["closed_prs_count"] == 1
-
-
 def test_library_detail_context_get_maintainers(tp, user, library_version):
     """
     GET /libraries/{slug}/
@@ -146,25 +127,6 @@ def test_library_detail_context_get_maintainers(tp, user, library_version):
     assert "maintainers" in response.context
     assert len(response.context["maintainers"]) == 1
     assert response.context["maintainers"][0] == user
-
-
-def test_library_detail_context_get_open_issues_count(tp, library_version):
-    """
-    GET /libraries/{slug}/
-    Test that the custom open_issues_count var appears as expected
-    """
-    library = library_version.library
-    # Create open and closed issues for this library, and another random issue
-    lib2 = baker.make("libraries.Library", slug="sample")
-    baker.make("libraries.Issue", library=library, is_open=True)
-    baker.make("libraries.Issue", library=library, is_open=False)
-    baker.make("libraries.Issue", library=lib2, is_open=True)
-    url = tp.reverse("library-detail", library.slug)
-    response = tp.get(url)
-    tp.response_200(response)
-    assert "open_issues_count" in response.context
-    # Verify that the count only includes the one open issue for this library
-    assert response.context["open_issues_count"] == 1
 
 
 def test_libraries_by_version_detail(tp, library_version):

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -8,7 +8,7 @@ from django.views.generic.edit import FormMixin
 from versions.models import Version
 from .forms import VersionSelectionForm
 from .github import GithubAPIClient
-from .models import Category, Issue, Library, LibraryVersion, PullRequest
+from .models import Category, Library, LibraryVersion
 
 logger = structlog.get_logger()
 
@@ -106,8 +106,6 @@ class LibraryDetail(CategoryMixin, FormMixin, DetailView):
     def get_context_data(self, **kwargs):
         """Set the form action to the main libraries page"""
         context = super().get_context_data(**kwargs)
-        context["closed_prs_count"] = self.get_closed_prs_count(self.object)
-        context["open_issues_count"] = self.get_open_issues_count(self.object)
         context["version"] = self.get_version()
         context["maintainers"] = self.get_maintainers(context["version"])
         context["versions"] = (
@@ -140,19 +138,11 @@ class LibraryDetail(CategoryMixin, FormMixin, DetailView):
             raise Http404("No library found matching the query")
         return obj
 
-    def get_closed_prs_count(self, obj):
-        """Get the number of closed pull requests for the current library."""
-        return PullRequest.objects.filter(library=obj, is_open=True).count()
-
     def get_maintainers(self, version):
         """Get the maintainers for the current LibraryVersion."""
         obj = self.get_object()
         library_version = LibraryVersion.objects.get(library=obj, version=version)
         return library_version.maintainers.all()
-
-    def get_open_issues_count(self, obj):
-        """Get the number of open issues for the current library."""
-        return Issue.objects.filter(library=obj, is_open=True).count()
 
     def get_version(self):
         """Get the version of Boost for the library we're currently looking at."""


### PR DESCRIPTION
@frankwiles We can probably get rid of the models and the code that populates them entirely, actually. We're only using commit data, not PR or issue data. Just wanted it to not clutter up the view anymore! 