### PR TITLE
#252 Make library detail page category link version-sensitive

### DIFF
--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -65,7 +65,7 @@
 
               <span class="block py-1 px-2 rounded cursor-pointer hover:bg-gray-100">Categories:
                 {% for category in object.categories.all %}
-                  <a class="inline text-sky-600" href="{% url 'libraries' %}?category={{ category.slug }}">{{ category.name }}</a>
+                  <a class="inline text-sky-600" href="{% url 'libraries' %}?category={{ category.slug }}{% if version %}&version={{ version.slug }}{% endif %}">{{ category.name }}</a>
                 {% endfor %}
               </span>
 


### PR DESCRIPTION
Part of #252. Includes the version filter in the link to the category list page from the library detail page. 