### PR TITLE
Upgrade crypto, change `python-dev` installation in Dockerfile 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM python:3.11-slim AS builder-py
 
-RUN apt update && apt install -y build-essential gcc python-dev libpq-dev postgresql-client ruby ruby-dev && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y build-essential gcc python-dev-is-python3 libpq-dev postgresql-client ruby ruby-dev && rm -rf /var/lib/apt/lists/*
 
 # Install Asciidoctor
 RUN gem install asciidoctor

--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,7 @@ Pillow==9.4.0
 python-dateutil
 django-storages
 wheel
-cryptography
+cryptography>=41.0.0
 boto3
 
 # Logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ click-repl==0.2.0
     # via celery
 coverage[toml]==7.2.6
     # via pytest-cov
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r ./requirements.in
     #   django-anymail


### PR DESCRIPTION
Closes https://github.com/cppalliance/temp-site/security/dependabot/38 with an upgrade to `cryptography`. Also updates the `python-dev` install in the Dockerfile after I ran into an error rebuilding. I used the replacement package the error message suggested. 

Error message: 
```
#13 3.786 Package python-dev is not available, but is referred to by another package.
#13 3.786 This may mean that the package is missing, has been obsoleted, or
#13 3.786 is only available from another source
#13 3.786 However the following packages replace it:
#13 3.787   python-dev-is-python3
#13 3.787 
#13 3.789 E: Package 'python-dev' has no installation candidate
```