### PR TITLE
Run pip-compile upgrade

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,7 @@ Pillow==9.4.0
 python-dateutil
 django-storages
 wheel
-cryptography>=41.0.0
+cryptography
 boto3
 
 # Logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ amqp==5.1.1
     # via kombu
 appdirs==1.4.4
     # via fs
-asgiref==3.7.0
+asgiref==3.7.2
     # via django
 asttokens==2.2.1
     # via stack-data
@@ -20,13 +20,13 @@ beautifulsoup4==4.12.2
     # via -r ./requirements.in
 billiard==3.6.4.0
     # via celery
-black==22.3
+black==23.3.0
     # via -r ./requirements.in
-boto3==1.26.139
+boto3==1.26.154
     # via
     #   -r ./requirements.in
     #   django-bakery
-botocore==1.29.139
+botocore==1.29.154
     # via
     #   boto3
     #   s3transfer
@@ -61,9 +61,9 @@ click-didyoumean==0.3.0
     # via celery
 click-plugins==1.1.1
     # via celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via celery
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via pytest-cov
 cryptography==41.0.1
     # via
@@ -80,7 +80,7 @@ dj-database-url==2.0.0
     # via environs
 dj-email-url==1.0.6
     # via environs
-django==4.2.1
+django==4.2.2
     # via
     #   -r ./requirements.in
     #   dj-database-url
@@ -111,7 +111,7 @@ django-click==2.3.0
     # via -r ./requirements.in
 django-db-geventpool==4.0.1
     # via -r ./requirements.in
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r ./requirements.in
 django-haystack==3.2.1
     # via
@@ -121,13 +121,13 @@ django-health-check==3.17.0
     # via -r ./requirements.in
 django-js-asset==2.0.0
     # via django-mptt
-django-machina==1.2.0
+django-machina==1.3.0
     # via -r ./requirements.in
 django-mptt==0.14.0
     # via
     #   -r ./requirements.in
     #   django-machina
-django-redis==5.2.0
+django-redis==5.3.0
     # via -r ./requirements.in
 django-rest-auth==0.9.5
     # via -r ./requirements.in
@@ -149,7 +149,7 @@ environs[django]==9.5.0
     # via -r ./requirements.in
 executing==1.2.0
     # via stack-data
-faker==18.9.0
+faker==18.10.1
     # via -r ./requirements.in
 fastcore==1.5.29
     # via ghapi
@@ -159,7 +159,7 @@ fs==2.4.16
     # via django-bakery
 gevent==22.10.2
     # via -r ./requirements.in
-ghapi==1.0.3
+ghapi==1.0.4
     # via -r ./requirements.in
 greenlet==2.0.1
     # via
@@ -173,7 +173,7 @@ idna==3.4
     # via requests
 iniconfig==2.0.0
     # via pytest
-ipython==8.13.2
+ipython==8.14.0
     # via -r ./requirements.in
 jedi==0.18.2
     # via ipython
@@ -181,7 +181,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-kombu==5.2.4
+kombu==5.3.1
     # via celery
 markdown2==2.4.8
     # via django-machina
@@ -191,9 +191,9 @@ matplotlib-inline==0.1.6
     # via ipython
 minio==7.1.15
     # via -r ./requirements.in
-mistletoe==1.0.1
+mistletoe==1.1.0
     # via -r ./requirements.in
-model-bakery==1.11.0
+model-bakery==1.12.0
     # via -r ./requirements.in
 mypy-extensions==1.0.0
     # via black
@@ -203,6 +203,7 @@ oauthlib==3.2.2
     # via requests-oauthlib
 packaging==23.1
     # via
+    #   black
     #   build
     #   fastcore
     #   ghapi
@@ -222,7 +223,7 @@ pillow==9.4.0
     #   django-machina
 pip-tools==6.13.0
     # via -r ./requirements.in
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via
     #   black
     #   virtualenv
@@ -250,12 +251,12 @@ pyjwt[crypto]==2.7.0
     # via django-allauth
 pyproject-hooks==1.0.0
     # via build
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   -r ./requirements.in
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r ./requirements.in
 pytest-django==4.5.2
     # via -r ./requirements.in
@@ -300,7 +301,6 @@ s3transfer==0.6.1
     # via boto3
 six==1.16.0
     # via
-    #   click-repl
     #   django-bakery
     #   django-rest-auth
     #   fs
@@ -319,7 +319,7 @@ traitlets==5.9.0
     #   matplotlib-inline
 types-pyyaml==6.0.12.10
     # via responses
-typing-extensions==4.6.0
+typing-extensions==4.6.3
     # via dj-database-url
 urllib3==1.26.16
     # via
@@ -340,7 +340,7 @@ wheel==0.40.0
     # via
     #   -r ./requirements.in
     #   pip-tools
-whitenoise==6.4.0
+whitenoise==6.5.0
     # via -r ./requirements.in
 zope-event==4.6
     # via gevent


### PR DESCRIPTION
Mainly for `cryptography` to address Vulnerable OpenSSL included in cryptography wheels