### PR TITLE
Expose last 12 months commit counts to template

### DIFF
--- a/libraries/managers.py
+++ b/libraries/managers.py
@@ -1,0 +1,35 @@
+import datetime
+
+from dateutil.relativedelta import relativedelta
+
+from django.db import models
+from django.db.models import Sum
+from django.db.models.functions import ExtractYear
+
+
+class CommitDataManager(models.Manager):
+    def get_annual_commit_data_for_library(self, library, branch="master"):
+        """Get the numbers of commits per year to a library and a branch."""
+        return (
+            self.filter(library=library, branch=branch)
+            .annotate(year=ExtractYear("month_year"))
+            .values("year")
+            .annotate(commit_count=Sum("commit_count"))
+            .order_by("year")
+        )
+
+    def get_commit_data_for_last_12_months_for_library(self, library, branch="master"):
+        """Get the number of commits per month for the last 12 months to a library
+        and a branch."""
+        today = datetime.date.today()
+        one_year_ago = today - relativedelta(years=1)
+        return (
+            self.filter(
+                library=library,
+                month_year__range=(one_year_ago, today),
+                branch=branch,
+            )
+            .values("month_year")
+            .annotate(commit_count=Sum("commit_count"))
+            .order_by("month_year")
+        )

--- a/libraries/models.py
+++ b/libraries/models.py
@@ -10,6 +10,7 @@ from core.markdown import process_md
 from core.models import RenderedContent
 from core.tasks import adoc_to_html
 
+from .managers import CommitDataManager
 from .utils import write_content_to_tempfile
 
 
@@ -55,6 +56,8 @@ class CommitData(models.Model):
         default="master",
         help_text="The GitHub branch to which these commits were made.",
     )
+
+    objects = CommitDataManager()
 
     class Meta:
         unique_together = ("library", "month_year", "branch")

--- a/libraries/tests/test_managers.py
+++ b/libraries/tests/test_managers.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
+from model_bakery import baker
+
+from ..models import CommitData
+
+
+def test_get_annual_commit_data_for_library(library):
+    five_years_ago = datetime.now().date().replace(year=datetime.now().year - 5)
+    for i in range(5):
+        date = five_years_ago.replace(year=five_years_ago.year + i)
+        baker.make(
+            "libraries.CommitData",
+            library=library,
+            month_year=date,
+            commit_count=i + 1,
+            branch="master",
+        )
+
+    result = CommitData.objects.get_annual_commit_data_for_library(library)
+    assert len(result) == 5
+    for i, data in enumerate(result):
+        assert data["year"] == five_years_ago.year + i
+        assert data["commit_count"] == i + 1
+
+
+def test_get_commit_data_for_last_12_months_for_library(library):
+    one_year_ago = datetime.now().date() - timedelta(days=365)
+    for i in range(12):
+        date = one_year_ago + relativedelta(months=i)
+        baker.make(
+            "libraries.CommitData",
+            library=library,
+            month_year=date,
+            commit_count=i + 1,
+            branch="master",
+        )
+
+    result = CommitData.objects.get_commit_data_for_last_12_months_for_library(library)
+    assert len(result) == 12
+    for i, data in enumerate(result):
+        assert data["month_year"] == one_year_ago + relativedelta(months=i)
+        assert data["commit_count"] == i + 1

--- a/libraries/tests/test_models.py
+++ b/libraries/tests/test_models.py
@@ -106,7 +106,8 @@ def test_library_repo_url_for_version_invalid_data(library_version):
 
     with pytest.raises(ValueError):
         library_version.library_repo_url_for_version
-        
+
+
 def test_library_version_documentation_url(library_version):
     library_version.version.slug = "boost-1.82.0"
     library_version.version.save()

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -1,5 +1,8 @@
 import datetime
 
+from django.utils import timezone
+from dateutil.relativedelta import relativedelta
+
 from model_bakery import baker
 
 
@@ -109,8 +112,6 @@ def test_library_detail_404(library, tp):
     tp.response_404(response)
 
 
-<<<<<<< HEAD
-=======
 def test_library_detail_context_get_commit_data_annual(tp, library_version):
     """
     GET /libraries/{slug}/
@@ -154,7 +155,7 @@ def test_library_detail_context_get_commit_data_annual(tp, library_version):
     # Verify that the data is only for last 12 months for this library
     assert len(commit_data_annual) == 10
     for i, data in enumerate(reversed(commit_data_annual)):
-        assert data["year"] == current_year - i
+        assert data["date"] == datetime.date(current_year - i, 1, 1)
         assert data["commit_count"] == i + 1
 
 
@@ -167,6 +168,7 @@ def test_library_detail_context_get_commit_data_last_12_months(tp, library_versi
 
     # Create CommitData for the library and another random library
     random_library = baker.make("libraries.Library", slug="random")
+
     current_month = timezone.now().date().replace(day=1)
     for i in range(12):
         date = current_month - relativedelta(months=i)
@@ -187,11 +189,10 @@ def test_library_detail_context_get_commit_data_last_12_months(tp, library_versi
     # Verify that the data is only for last 12 months for this library
     assert len(commit_data_last_12_months) == 12
     for i, data in enumerate(reversed(commit_data_last_12_months)):
-        assert data["month_year"] == current_month - relativedelta(months=i)
+        assert data["date"] == current_month - relativedelta(months=i)
         assert data["commit_count"] == i + 1
 
 
->>>>>>> a7a5d70 (Add retrieval of annual commit data)
 def test_library_detail_context_get_maintainers(tp, user, library_version):
     """
     GET /libraries/{slug}/


### PR DESCRIPTION
Closes #252 

cc @gregnewman  -- this is the PR that will get those commit count graphs populated! 


The data comes to the template in the detail view in two variables: `commit_data_annual` and `commit_data_last_12_months`. Each field is a list of dicts, in date order: 

```
[{"date": python datetime, "commit_count": int}]
```

You can filter the `date` using the template filters to display the month and/or year as needed. **NOTE**: This data does not currently change with the version -- it's always retrieving commits to `master`. 

I didn't actually add the data to the template in this PR. 

_Edit_ Messed something up when rebasing and have to fix it. 