### PR TITLE
Add "older version" notice to all library list pages 

### DIFF
--- a/libraries/mixins.py
+++ b/libraries/mixins.py
@@ -1,0 +1,43 @@
+import structlog
+
+from versions.models import Version
+from .models import Category
+
+
+logger = structlog.get_logger()
+
+
+class CategoryMixin:
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["categories"] = Category.objects.all().order_by("name")
+        return context
+
+
+class VersionAlertMixin:
+    """Mixin to selectively add a version alert to the context"""
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        # Get the version from the GET parameters or default to the latest
+        version_slug = self.request.GET.get(
+            "version", Version.objects.most_recent().slug
+        )
+
+        try:
+            selected_version = Version.objects.get(slug=version_slug)
+        except Version.DoesNotExist:
+            selected_version = Version.objects.most_recent()
+
+        # compare the selected version with the latest version
+        latest_version = Version.objects.most_recent()
+        context["latest_version"] = latest_version
+        context["version"] = selected_version
+
+        if selected_version != latest_version:
+            context["version_alert"] = True
+        else:
+            context["version_alert"] = False
+
+        return context

--- a/libraries/tests/test_mixins.py
+++ b/libraries/tests/test_mixins.py
@@ -1,0 +1,41 @@
+import datetime
+import pytest
+from django.test import RequestFactory
+from model_bakery import baker
+from libraries.mixins import VersionAlertMixin
+from libraries.views import LibraryList
+
+
+class MockView(LibraryList, VersionAlertMixin):
+    pass
+
+
+@pytest.mark.django_db
+def test_version_alert_mixin(version):
+    latest_version = version
+    old_version = baker.make("versions.Version", release_date=datetime.date(2000, 1, 1))
+
+    # instantiate the mock view
+    view = MockView()
+
+    # create a mock request with no GET parameters
+    request = RequestFactory().get("/")
+    view.request = request
+
+    # call get_context_data and check the context
+    view.object_list = view.get_queryset()
+    context = view.get_context_data()
+    assert context["version"] == latest_version
+    assert context["latest_version"] == latest_version
+    assert not context["version_alert"]
+
+    # create a mock request with a GET parameter for an old version
+    request = RequestFactory().get(f"/?version={old_version.slug}")
+    view.request = request
+
+    # call get_context_data and check the context
+    view.object_list = view.get_queryset()
+    context = view.get_context_data()
+    assert context["version"] == old_version
+    assert context["latest_version"] == latest_version
+    assert context["version_alert"]

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -10,19 +10,13 @@ from django.views.generic.edit import FormMixin
 from versions.models import Version
 from .forms import VersionSelectionForm
 from .github import GithubAPIClient
+from .mixins import CategoryMixin, VersionAlertMixin
 from .models import Category, CommitData, Library, LibraryVersion
 
 logger = structlog.get_logger()
 
 
-class CategoryMixin:
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["categories"] = Category.objects.all().order_by("name")
-        return context
-
-
-class LibraryList(CategoryMixin, ListView):
+class LibraryList(CategoryMixin, VersionAlertMixin, ListView):
     """List all of our libraries for a specific Boost version, or default
     to the current version."""
 

--- a/templates/libraries/category_list.html
+++ b/templates/libraries/category_list.html
@@ -77,6 +77,9 @@
     </form>
   </div>
 
+  <!-- alert for non-current Boost versions -->
+  {% include "libraries/includes/version_alert.html" %}
+
   <!-- Libraries list -->
   <div class="space-y-3">
     {% if by_category %}

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -40,6 +40,9 @@
           </h3>
         </div>
 
+        <!-- alert for non-current Boost versions -->
+        {% include "libraries/includes/version_alert.html" %}
+
         <div class="p-4 md:flex md:space-x-3">
           <div class="px-2 pt-2 space-y-2 w-full bg-white rounded-lg md:w-1/3 dark:bg-charcoal">
               <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100" href="{{ documentation_url }}">

--- a/templates/libraries/flat_list.html
+++ b/templates/libraries/flat_list.html
@@ -77,6 +77,9 @@
     </form>
   </div>
 
+  <!-- alert for non-current Boost versions -->
+  {% include "libraries/includes/version_alert.html" %}
+
   <!-- Libraries list -->
   <div class="relative content-between p-3 w-full bg-white rounded-lg shadow-lg md:p-5 dark:bg-charcoal">
     {% if by_category %}

--- a/templates/libraries/includes/version_alert.html
+++ b/templates/libraries/includes/version_alert.html
@@ -1,5 +1,13 @@
 {% if version_alert %}
     <div role="alert">
-        <p>This is an older version and was released in {{ version.release_date|date:"Y"}}. The current version is <a href="{% url 'version-detail' latest_version.slug %}">{{ latest_version.display_name }}</a>.</p>
+        <p>This is an older version and was released in {{ version.release_date|date:"Y"}}.
+           The current version is
+            {% if latest_library_version %}
+                <a href="{% url 'library-detail' slug=latest_library_version.library.slug %}">
+            {% else %}
+                <a href="{% url 'version-detail' latest_version.slug %}">
+            {% endif %}
+            {{ latest_version.display_name }}</a>.
+        </p>
     </div>
 {% endif %}

--- a/templates/libraries/includes/version_alert.html
+++ b/templates/libraries/includes/version_alert.html
@@ -1,0 +1,5 @@
+{% if version_alert %}
+    <div role="alert">
+        <p>This is an older version and was released in {{ version.release_date|date:"Y"}}. The current version is <a href="{% url 'version-detail' latest_version.slug %}">{{ latest_version.display_name }}</a>.</p>
+    </div>
+{% endif %}

--- a/templates/libraries/list.html
+++ b/templates/libraries/list.html
@@ -77,6 +77,9 @@
     </form>
   </div>
 
+  <!-- alert for non-current Boost versions -->
+  {% include "libraries/includes/version_alert.html" %}
+
   <!-- Libraries list -->
   <div class="grid grid-cols-1 gap-4 mb-5 md:grid-cols-2 xl:grid-cols-3">
     {% if by_category %}


### PR DESCRIPTION
- Adds a mixin for the list views and includes it in the view. Detail logic is a little different. 
- Adds a template for the message 
- Includes that template in the other list templates and the detail template 
- Moves mixins to their own module 

Closes #282.
@gregnewman I did not do much with styling this so it may need your help! 

@frankwiles and @vinniefalco Right now, on the versions list page, the alert link directs to the versions page: https://www.boost.revsys.dev/versions/boost-1-82-0/. But I know we also have a "releases" mockup page: https://www.boost.revsys.dev/releases/. Which one should I link to, or should I link back to the library list page for the current version? (The detail page alert links to the current version of that specific library detail page.) 

## List page alert 
<img width="1909" alt="Screenshot 2023-06-22 at 2 48 10 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/2fd2645c-61bb-4a1e-8483-fda66f2f1adc">


## Detail page alert 
<img width="963" alt="Screenshot 2023-06-22 at 3 57 12 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/410820db-45be-4f03-a9cb-f78787cd8028">
