### PR TITLE
Add view to clear static content cache (redis and database) by content type or cache_key 

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -25,7 +25,7 @@ from ak.views import (
     OKView,
     HomepageBetaView,
 )
-from core.views import MarkdownTemplateView, StaticContentTemplateView
+from core.views import ClearCacheView, MarkdownTemplateView, StaticContentTemplateView
 from libraries.views import (
     LibraryList,
     LibraryListMini,
@@ -247,6 +247,8 @@ urlpatterns = (
         # Boost versions views
         path("versions/<slug:slug>/", VersionDetail.as_view(), name="version-detail"),
         path("versions/", VersionList.as_view(), name="version-list"),
+        # Internal functions
+        path("internal/clear-cache/", ClearCacheView.as_view(), name="clear-cache"),
     ]
     + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     + [

--- a/core/managers.py
+++ b/core/managers.py
@@ -1,5 +1,6 @@
 import structlog
 
+from django.core.cache import caches
 from django.db import models
 
 logger = structlog.get_logger()
@@ -7,6 +8,7 @@ logger = structlog.get_logger()
 
 class RenderedContentManager(models.Manager):
     def delete_by_content_type(self, content_type):
+        """Deletes all rendered content of a given type."""
         self.filter(content_type=content_type).delete()
         logger.info(
             "rendered_content_manager_delete_by_content_type", content_type=content_type

--- a/core/managers.py
+++ b/core/managers.py
@@ -1,0 +1,13 @@
+import structlog
+
+from django.db import models
+
+logger = structlog.get_logger()
+
+
+class RenderedContentManager(models.Manager):
+    def delete_by_content_type(self, content_type):
+        self.filter(content_type=content_type).delete()
+        logger.info(
+            "rendered_content_manager_delete_by_content_type", content_type=content_type
+        )

--- a/core/managers.py
+++ b/core/managers.py
@@ -13,3 +13,17 @@ class RenderedContentManager(models.Manager):
         logger.info(
             "rendered_content_manager_delete_by_content_type", content_type=content_type
         )
+
+    def clear_cache_by_content_type(self, content_type):
+        """Clears the static content cache of all rendered content of a given type."""
+        cache = caches["static_content"]
+        results = self.filter(content_type=content_type)
+        for result in results:
+            cache.delete(result.cache_key)
+
+        logger.info(
+            "rendered_content_manager_clear_cache_by_content_type",
+            cache_name="static_content",
+            content_type=content_type,
+            count=len(results),
+        )

--- a/core/managers.py
+++ b/core/managers.py
@@ -7,13 +7,6 @@ logger = structlog.get_logger()
 
 
 class RenderedContentManager(models.Manager):
-    def delete_by_content_type(self, content_type):
-        """Deletes all rendered content of a given type."""
-        self.filter(content_type=content_type).delete()
-        logger.info(
-            "rendered_content_manager_delete_by_content_type", content_type=content_type
-        )
-
     def clear_cache_by_content_type(self, content_type):
         """Clears the static content cache of all rendered content of a given type."""
         cache = caches["static_content"]
@@ -26,4 +19,16 @@ class RenderedContentManager(models.Manager):
             cache_name="static_content",
             content_type=content_type,
             count=len(results),
+        )
+
+    def delete_by_cache_key(self, cache_key):
+        """Deletes a rendered content object by its cache key."""
+        self.filter(cache_key=cache_key).delete()
+        logger.info("rendered_content_manager_delete_by_cache_key", cache_key=cache_key)
+
+    def delete_by_content_type(self, content_type):
+        """Deletes all rendered content of a given type."""
+        self.filter(content_type=content_type).delete()
+        logger.info(
+            "rendered_content_manager_delete_by_content_type", content_type=content_type
         )

--- a/core/models.py
+++ b/core/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from .managers import RenderedContentManager
+
 
 class RenderedContent(models.Model):
     """Stores a copy of rendered content. Generally, this content is retrieved
@@ -33,6 +35,8 @@ class RenderedContent(models.Model):
         null=True,
         blank=True,
     )
+
+    objects = RenderedContentManager()
 
     class Meta:
         verbose_name = _("rendered content")

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -44,21 +44,7 @@ def adoc_to_html(file_path, delete_file=True):
 
 
 @shared_task
-def clear_cache(cache_name="static_content"):
-    cache = caches.get(cache_name)
-    if cache:
-        keys = static_content_cache.keys("static_content_*")
-        for key in keys:
-            static_content_cache.delete(key)
-
-
-@shared_task
-def clear_rendered_content_by_content_type(content_type):
+def clear_rendered_content_cache_by_content_type(content_type):
     """Deletes all RenderedContent objects for a given content type"""
+    RenderedContent.objects.clear_cache_by_content_type(content_type)
     RenderedContent.objects.delete_by_content_type(content_type)
-
-
-# @shared_task
-# def clear_all_caches():
-#     clear_cache.delay()
-#     clear_database.delay()

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -44,7 +44,17 @@ def adoc_to_html(file_path, delete_file=True):
 
 
 @shared_task
+def clear_rendered_content_cache_by_cache_key(cache_key):
+    """Deletes a RenderedContent object by its cache key from redis and
+    database."""
+    cache = caches["static_content"]
+    cache.delete(cache_key)
+    RenderedContent.objects.delete_by_cache_key(cache_key)
+
+
+@shared_task
 def clear_rendered_content_cache_by_content_type(content_type):
-    """Deletes all RenderedContent objects for a given content type"""
+    """Deletes all RenderedContent objects for a given content type from redis
+    and database."""
     RenderedContent.objects.clear_cache_by_content_type(content_type)
     RenderedContent.objects.delete_by_content_type(content_type)

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -4,6 +4,10 @@ import subprocess
 
 from celery import shared_task
 
+from django.core.cache import caches
+
+from .models import RenderedContent
+
 
 @shared_task
 def adoc_to_html(file_path, delete_file=True):
@@ -37,3 +41,24 @@ def adoc_to_html(file_path, delete_file=True):
         os.remove(file_path)
 
     return converted_html
+
+
+@shared_task
+def clear_cache(cache_name="static_content"):
+    cache = caches.get(cache_name)
+    if cache:
+        keys = static_content_cache.keys("static_content_*")
+        for key in keys:
+            static_content_cache.delete(key)
+
+
+@shared_task
+def clear_rendered_content_by_content_type(content_type):
+    """Deletes all RenderedContent objects for a given content type"""
+    RenderedContent.objects.delete_by_content_type(content_type)
+
+
+# @shared_task
+# def clear_all_caches():
+#     clear_cache.delay()
+#     clear_database.delay()

--- a/core/tests/test_managers.py
+++ b/core/tests/test_managers.py
@@ -1,0 +1,15 @@
+from model_bakery import baker
+from ..models import RenderedContent
+
+
+def test_rendered_content_manager_delete_by_content_type():
+    baker.make("core.RenderedContent", content_type="keep")
+    baker.make("core.RenderedContent", content_type="clear")
+
+    assert RenderedContent.objects.filter(content_type="keep").exists()
+    assert RenderedContent.objects.filter(content_type="clear").exists()
+
+    RenderedContent.objects.delete_by_content_type("clear")
+
+    assert RenderedContent.objects.filter(content_type="keep").exists()
+    assert not RenderedContent.objects.filter(content_type="clear").exists()

--- a/core/tests/test_managers.py
+++ b/core/tests/test_managers.py
@@ -1,5 +1,18 @@
 from model_bakery import baker
+
+from django.core.cache import caches
+from django.test import override_settings
+
 from ..models import RenderedContent
+
+
+TEST_CACHES = {
+    "static_content": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "third-unique-snowflake",
+        "TIMEOUT": "60",  # Cache timeout in seconds: 1 minute
+    },
+}
 
 
 def test_rendered_content_manager_delete_by_content_type():
@@ -13,3 +26,21 @@ def test_rendered_content_manager_delete_by_content_type():
 
     assert RenderedContent.objects.filter(content_type="keep").exists()
     assert not RenderedContent.objects.filter(content_type="clear").exists()
+
+
+@override_settings(CACHES=TEST_CACHES)
+def test_rendered_content_manager_clear_cache_by_content_type():
+    baker.make("core.RenderedContent", content_type="keep", cache_key="keep")
+    baker.make("core.RenderedContent", content_type="clear", cache_key="clear")
+
+    cache = caches["static_content"]
+    cache.set("keep", "keep")
+    cache.set("clear", "clear")
+
+    assert cache.get("keep") == "keep"
+    assert cache.get("clear") == "clear"
+
+    RenderedContent.objects.clear_cache_by_content_type("clear")
+
+    assert cache.get("keep") == "keep"
+    assert cache.get("clear") is None

--- a/core/tests/test_managers.py
+++ b/core/tests/test_managers.py
@@ -44,3 +44,16 @@ def test_rendered_content_manager_clear_cache_by_content_type():
 
     assert cache.get("keep") == "keep"
     assert cache.get("clear") is None
+
+
+def test_delete_by_cache_key():
+    baker.make("core.RenderedContent", cache_key="keep")
+    baker.make("core.RenderedContent", cache_key="clear")
+
+    assert RenderedContent.objects.filter(cache_key="keep").exists()
+    assert RenderedContent.objects.filter(cache_key="clear").exists()
+
+    RenderedContent.objects.delete_by_cache_key("clear")
+
+    assert RenderedContent.objects.filter(cache_key="keep").exists()
+    assert not RenderedContent.objects.filter(cache_key="clear").exists()

--- a/core/tests/test_tasks.py
+++ b/core/tests/test_tasks.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 from django.core.cache import caches
 from django.test import override_settings
 
-from core.tasks import adoc_to_html
+from core.models import RenderedContent
+from core.tasks import adoc_to_html, clear_rendered_content_by_content_type
 
 
 @override_settings(
@@ -46,3 +47,13 @@ def test_adoc_to_html():
     with pytest.raises(FileNotFoundError):
         with open(temp_file_path, "r"):
             pass
+
+
+def test_clear_rendered_content_by_content_type(rendered_content):
+    assert RenderedContent.objects.filter(
+        content_type=rendered_content.content_type
+    ).exists()
+    clear_rendered_content_by_content_type(rendered_content.content_type)
+    assert not RenderedContent.objects.filter(
+        content_type=rendered_content.content_type
+    ).exists()

--- a/core/tests/test_tasks.py
+++ b/core/tests/test_tasks.py
@@ -2,30 +2,28 @@ import pytest
 import tempfile
 from unittest.mock import patch
 
+from model_bakery import baker
+
 from django.core.cache import caches
 from django.test import override_settings
 
 from core.models import RenderedContent
-from core.tasks import adoc_to_html, clear_rendered_content_by_content_type
-
-
-@override_settings(
-    CACHES={
-        "default": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "unique-snowflake",
-        },
-        "machina_attachments": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "another-unique-snowflake",
-        },
-        "static_content": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "third-unique-snowflake",
-            "TIMEOUT": "60",  # Cache timeout in seconds: 1 minute
-        },
-    }
+from core.tasks import (
+    adoc_to_html,
+    clear_rendered_content_cache_by_content_type,
 )
+
+
+TEST_CACHES = {
+    "static_content": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "third-unique-snowflake",
+        "TIMEOUT": "60",  # Cache timeout in seconds: 1 minute
+    },
+}
+
+
+@override_settings(CACHES=TEST_CACHES)
 def test_adoc_to_html():
     # Get the static content cache
     caches["static_content"]
@@ -49,11 +47,22 @@ def test_adoc_to_html():
             pass
 
 
-def test_clear_rendered_content_by_content_type(rendered_content):
-    assert RenderedContent.objects.filter(
-        content_type=rendered_content.content_type
-    ).exists()
-    clear_rendered_content_by_content_type(rendered_content.content_type)
-    assert not RenderedContent.objects.filter(
-        content_type=rendered_content.content_type
-    ).exists()
+@override_settings(CACHES=TEST_CACHES)
+def test_clear_rendered_content_by_content_type():
+    baker.make("core.RenderedContent", content_type="keep", cache_key="keep")
+    baker.make("core.RenderedContent", content_type="clear", cache_key="clear")
+
+    cache = caches["static_content"]
+    cache.set("keep", "keep")
+    cache.set("clear", "clear")
+
+    assert cache.get("keep") == "keep"
+    assert cache.get("clear") == "clear"
+
+    clear_rendered_content_cache_by_content_type("clear")
+
+    assert cache.get("keep") == "keep"
+    assert cache.get("clear") is None
+
+    assert RenderedContent.objects.filter(content_type="keep").exists()
+    assert not RenderedContent.objects.filter(content_type="clear").exists()

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -19,6 +19,13 @@ TEST_CACHES = {
 
 
 @pytest.fixture
+def cache_url(tp):
+    """Returns a sample cache url."""
+    url = tp.reverse("clear-cache")
+    return f"{url}?content_type=foo"
+
+
+@pytest.fixture
 def request_factory():
     """Returns a RequestFactory instance."""
     return RequestFactory()
@@ -92,6 +99,27 @@ def test_cache_expiration(request_factory):
         {"content": mock_content, "content_type": mock_content_type},
         timeout=1,
     )
+
+
+def test_clear_cache_view_anonymous_user(tp, cache_url):
+    """Test that only staff users can access the clear cache view."""
+    # Anonymous users should be redirected to the login page
+    res = tp.get(cache_url)
+    tp.response_403(res)
+
+
+def test_clear_cache_regular_user(tp, user, cache_url):
+    """Test that only staff users can access the clear cache view."""
+    tp.login(user)
+    res = tp.get(cache_url)
+    tp.response_403(res)
+
+
+def test_clear_cache_staff_user(tp, staff_user, cache_url):
+    # Staff users should be able to access the view
+    tp.login(staff_user)
+    res = tp.get(cache_url)
+    tp.response_200(res)
 
 
 def test_markdown_view_top_level(tp):

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -122,6 +122,21 @@ def test_clear_cache_staff_user(tp, staff_user, cache_url):
     tp.response_200(res)
 
 
+def test_clear_cache_missing_params(tp, staff_user):
+    url = tp.reverse("clear-cache")
+    tp.login(staff_user)
+    res = tp.get(url)
+    tp.response_404(res)
+
+
+def test_clear_cache_by_cache_key(tp, staff_user):
+    url = tp.reverse("clear-cache")
+    url = f"{url}?cache_key=foo"
+    tp.login(staff_user)
+    res = tp.get(url)
+    tp.response_200(res)
+
+
 def test_markdown_view_top_level(tp):
     """GET /content/map"""
     res = tp.get("/markdown/foo")


### PR DESCRIPTION
Closes #394 

- Adds model managers to delete `RenderedContent` objects by `content_type` (example: "text/asciidoc") or by `cache_key`, and clear cache by `content_type` (Clearing the cache by a key is simple enough to do directly in the task 
- Adds tasks that clear the redis and database caches via the model managers (or directly) to perform those functions 
- Adds a url route and view that allow a staff user to clear the static content cache by passing query params to a url, then passing those values async to the celery tasks 

**Note**: I didn't do any styling on this. @frankwiles I wasn't sure what you meant by "code to bust the cache" in the original ticket #394 but the bulk of the logic is in tasks anyway so this can be adjusted. 

## Instructions 

- Log in as a staff user 
- Navigate to `/internal/clear-cache/?content_type=text/asciidoc` or `/internal/clear-cache/?cache_key=foo` (You can also pass both params but it currently defaults to clearing based on the **individual** params, so it would clear the content_types that matched and then any leftover cache_keys that matched. It clears more rather than less, basically.)
- You'll see a blank page with a success message, and the tasks perform in the background. 

<img width="651" alt="Screenshot 2023-06-26 at 6 13 16 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/321317e2-fbce-459f-8250-608b58f5ebda">
