### PR TITLE
Fix libraries formatting/filtering bug

### DIFF
--- a/templates/libraries/category_list.html
+++ b/templates/libraries/category_list.html
@@ -32,7 +32,7 @@
     {% include "libraries/includes/search_command_palatte.html" %}
 
 
-    <form action="/libraries/" method="get">
+    <form action="." method="get">
       <div class="flex relative space-x-3">
         <!-- Search -->
         <div class="relative">

--- a/templates/libraries/flat_list.html
+++ b/templates/libraries/flat_list.html
@@ -32,7 +32,7 @@
     {% include "libraries/includes/search_command_palatte.html" %}
 
 
-    <form action="/libraries/" method="get">
+    <form action="." method="get">
       <div class="flex relative space-x-3">
         <!-- Search -->
         <div class="relative">

--- a/templates/libraries/list.html
+++ b/templates/libraries/list.html
@@ -32,7 +32,7 @@
     {% include "libraries/includes/search_command_palatte.html" %}
 
 
-    <form action="/libraries/" method="get">
+    <form action="." method="get">
       <div class="flex relative space-x-3">
         <!-- Search -->
         <div class="relative">


### PR DESCRIPTION
@frankwiles You were right! 

This PR fixes a bug where, when a user was on the library list page, if they selected another format to view libraries (by category, or the flat version), then selected a version or category from the drop-down, they would be shown results in the regular format. 

## Broken in dev 
https://github.com/cppalliance/temp-site/assets/2286304/5f4b50f2-5402-451b-97ab-3b0d7e61adc9

## All fixed locally 
https://github.com/cppalliance/temp-site/assets/2286304/85b77f0a-15f0-443b-8bce-ebdf1f3866f9

