### PR TITLE
Fix 404 error when user cancels a GitHub signup 

### DIFF
--- a/docs/development_setup_notes.md
+++ b/docs/development_setup_notes.md
@@ -2,8 +2,11 @@
 
 The procedure to configure a development environment is mainly covered in the top-level README.md. This document will contain more details about installing prerequisites: Just, Python 3.11, Docker, and Docker Compose.
 
-- [Windows](#Windows)
+- [Development Setup Notes](#development-setup-notes)
+- [Windows](#windows)
 - [Ubuntu 22.04](#ubuntu-2204)
+- [Local Development](#local-development)
+  - [Social Login with django-allauth](#social-login-with-django-allauth)
 
 
 ## Windows
@@ -98,3 +101,40 @@ cp env.template .env
 Continue (as the root user) to the instructions in the top-level README.md file. Or if using WSL, review the last few steps in that section again.
 
 The advantage of running `docker compose` as root is the userid (0) will match the containers and the shared files.
+
+## Local Development
+
+### Social Login with django-allauth
+
+Follow these instructions to use the social logins through django-allauth on your local machine.
+
+See https://testdriven.io/blog/django-social-auth/ for more information.
+
+- Go to https://github.com/settings/applications/new and add a new OAuth application
+- Set `http://localhost:8000` as the Homepage URL
+- Set `http://localhost:8000/accounts/github/login/callback/` as the Callback URL
+- Click whether you want to enable the device flow
+
+<img src="https://user-images.githubusercontent.com/2286304/252841283-9a846c68-46bb-4dac-8d1e-d35270c09f1b.png" alt="The GitHub screen that registers a new OAuth app" width="400">
+
+- Log in to the admin
+- Click on Social Applications
+
+
+<img src="https://user-images.githubusercontent.com/2286304/204597123-3c8ae053-1ba8-4347-bacd-784fe52b2a04.png" alt="The Social Accounts section of the Django admin" width="400">
+
+- Click **Add Social Application**
+- Choose GitHub as the provider
+- Enter a name like "GitHub OAuth Provider"
+- Enter the Client ID from GitHub
+- Go back to GitHub and generate a new Client Secret, then copy it into the **Secret Key** field. Choose the site as a **Chosen sites** and save.
+
+<img src="https://user-images.githubusercontent.com/2286304/204648736-79aed1be-4b32-4946-be97-27e7c859603d.png" alt="Screenshot of where to get the Client ID and Client Secret" width="400">
+
+It's ready!
+
+**Working locally**: If you need to run through this flow multiple times, create a superuser so you can log into the admin. Then, log into the admin and delete your "Social Account" from the admin. This will test a fresh connection to GitHub for your logged-in GitHub user.
+
+To test the flow including authorizing Github for the Boost account, log into your GitHub account settings and click **Applications** in the left menu. Find the "Boost" authorization and delete it. The next time you log into Boost with this GitHub account, you will have to re-authorize it.
+
+<img src="https://user-images.githubusercontent.com/2286304/204642346-8b269aaf-4693-4351-9474-0a998b97689c.png" alt="The 'Authorized OAuth Apps' tab in your GitHub Applications" width="400">

--- a/templates/socialaccount/authentication_error.html
+++ b/templates/socialaccount/authentication_error.html
@@ -1,0 +1,11 @@
+{% extends "socialaccount/base.html" %}
+
+{% load i18n %}
+
+{% block head_title %}{% trans "Social Network Login Failure" %}{% endblock %}
+
+{% block content %}
+<h1>{% trans "Social Network Login Failure" %}</h1>
+
+<p>{% trans "An error occurred while attempting to login via your social network account." %}</p>
+{% endblock %}

--- a/templates/socialaccount/login_cancelled.html
+++ b/templates/socialaccount/login_cancelled.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+
+{% block head_title %}{% trans "Login Cancelled" %}{% endblock %}
+
+{% block content %}
+
+<h1>{% trans "Login Cancelled" %}</h1>
+
+{% url 'account_login' as login_url %}
+
+<p>{% blocktrans %}You decided to cancel logging in to our site using one of your existing accounts. If this was a mistake, please proceed to <a href="{{login_url}}">sign in</a>.{% endblocktrans %}</p>
+
+{% endblock %}


### PR DESCRIPTION
- Fixes #403 "page not found" error when user cancels a GitHub signup. 
- Also documents local dev setup for django-allauth. 

This was a weird one. When a user starts the process to sign up with GitHub, but cancels their registration on the screen where GitHub asks them for authorization, then the user would be redirected to a "page not found" screen. I figured out that the callback request when the user cancelled was being routed through the StaticContentView; I'm not sure why. I added some code to that view to catch these cases. 

Result: 

<img width="1371" alt="Screenshot 2023-07-11 at 7 38 22 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/57795be1-72b6-48d9-8311-d836cb7c17d6">
