### PR TITLE
Make categories in drop-down version-sensitive

### DIFF
--- a/libraries/mixins.py
+++ b/libraries/mixins.py
@@ -1,17 +1,9 @@
 import structlog
 
 from versions.models import Version
-from .models import Category
 
 
 logger = structlog.get_logger()
-
-
-class CategoryMixin:
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["categories"] = Category.objects.all().order_by("name")
-        return context
 
 
 class VersionAlertMixin:


### PR DESCRIPTION
Closes #278 by making the category drop-down include only categories that appear in the selected version's libraries. 

Refactored out the mixin as it wasn't needed anymore. 