### PR TITLE
Override password reset templates 

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -425,7 +425,9 @@ DEFAULT_FROM_EMAIL = "news@boost.org"
 SERVER_EMAIL = "errors@boost.org"
 
 # Deployed email configuration
-if not LOCAL_DEVELOPMENT:
+if LOCAL_DEVELOPMENT:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+else:
     EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
     ANYMAIL = {
         "MAILGUN_API_KEY": env("MAILGUN_API_KEY", default="changeme"),

--- a/templates/account/password_reset_done.html
+++ b/templates/account/password_reset_done.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% load account %}
+
+{% block head_title %}{% trans "Password Reset" %}{% endblock %}
+
+{% block content %}
+    <h1>{% trans "Password Reset" %}</h1>
+
+    {% if user.is_authenticated %}
+    {% include "account/snippets/already_logged_in.html" %}
+    {% endif %}
+
+    <p>{% blocktrans %}We have sent you an e-mail. If you have not received it please check your spam folder. Otherwise contact us if you do not receive it in a few minutes.{% endblocktrans %}</p>
+{% endblock %}

--- a/templates/account/password_reset_from_key.html
+++ b/templates/account/password_reset_from_key.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% block head_title %}{% trans "Change Password" %}{% endblock %}
+
+{% block content %}
+    <h1>{% if token_fail %}{% trans "Bad Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
+
+    {% if token_fail %}
+        {% url 'account_reset_password' as passwd_reset_url %}
+        <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
+    {% else %}
+        <form method="POST" action="{{ action_url }}">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <input type="submit" name="action" value="{% trans 'change password' %}"/>
+        </form>
+    {% endif %}
+{% endblock %}

--- a/templates/account/password_reset_from_key_done.html
+++ b/templates/account/password_reset_from_key_done.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% block head_title %}{% trans "Change Password" %}{% endblock %}
+
+{% block content %}
+    <h1>{% trans "Change Password" %}</h1>
+    <p>{% trans 'Your password is now changed.' %}</p>
+{% endblock %}


### PR DESCRIPTION
@gregnewman I tested the password reset flow in staging and it works, so I think you were right that it was the email not being set up. 

I found the relevant templates for the process and did the initial override to use our base template, so once this is merged, it's ready for the real design! (The text in the screenshots is huge because I bump up my font size 👓  ) 

Result:
<img width="1654" alt="Screenshot 2023-07-10 at 11 23 48 AM" src="https://github.com/cppalliance/temp-site/assets/2286304/f6b85620-6b42-4937-8ca7-1b6ca1739888">
<img width="1665" alt="Screenshot 2023-07-10 at 11 23 31 AM" src="https://github.com/cppalliance/temp-site/assets/2286304/00f128dd-327d-4585-ade0-b906df14f0f5">

<img width="854" alt="Screenshot 2023-07-10 at 11 24 40 AM" src="https://github.com/cppalliance/temp-site/assets/2286304/6fb1ba8e-c800-44ec-9e07-20a73dcdf35d">
