### PR TITLE
Override django-allauth social signup template

### DIFF
--- a/templates/socialaccount/signup.html
+++ b/templates/socialaccount/signup.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+
+{% block head_title %}{% trans "Signup" %}{% endblock %}
+
+{% block content %}
+    <h1>{% trans "Sign Up" %}</h1>
+
+<p>{% blocktrans with provider_name=account.get_provider.name site_name=site.name %}You are about to use your {{provider_name}} account to login to
+{{site_name}}. As a final step, please complete the following form:{% endblocktrans %}</p>
+
+<form class="signup" id="signup_form" method="post" action="{% url 'socialaccount_signup' %}">
+  {% csrf_token %}
+  {{ form.as_p }}
+  {% if redirect_field_value %}
+  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+  {% endif %}
+  <button type="submit">{% trans "Sign Up" %} &raquo;</button>
+</form>
+
+{% endblock %}


### PR DESCRIPTION
Overrides the screen that asks to confirm your email after you sign up

<img width="1123" alt="Screenshot 2023-07-10 at 12 26 26 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/8e62fe16-1ba3-43e0-8729-c5f73c8dc35b">
