### PR TITLE
492-see-old-releases

### DIFF
--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -8,7 +8,7 @@
   <div class="py-0 px-3 mb-3 md:py-0 md:px-0">
 
     <div class="py-0 md:px-0" x-data="{'showSearch': false}" x-on:keydown.escape="showSearch=false">
-      <form action="" method="post" class="float-right">
+      <form action="." method="post" class="float-right">
         {% csrf_token %}
         <div>
           <label for="id_version" hidden="true">Versions:</label>

--- a/versions/tests/test_views.py
+++ b/versions/tests/test_views.py
@@ -5,7 +5,7 @@ from model_bakery import baker
 
 def test_version_most_recent_detail(version, tp):
     """
-    GET /versions/{slug}/
+    GET /releases/
     """
     now = timezone.now()
 
@@ -18,7 +18,15 @@ def test_version_most_recent_detail(version, tp):
 
 def test_version_detail(version, tp):
     """
-    GET /versions/{slug}/
+    GET /releases/{slug}/
     """
     res = tp.get("release-detail", slug=version.slug)
+    tp.response_200(res)
+
+
+def test_version_detail_post(version, tp):
+    """
+    POST /releases/{slug}/
+    """
+    res = tp.post("releases-most-recent", data={"version": version.slug})
     tp.response_200(res)

--- a/versions/views.py
+++ b/versions/views.py
@@ -3,23 +3,6 @@ from django.views.generic import DetailView
 from versions.models import Version
 
 
-class VersionCurrentReleaseDetail(DetailView):
-    """Web display of list of Versions"""
-
-    model = Version
-    queryset = Version.objects.active()
-    template_name = "versions/detail.html"
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data()
-        context["versions"] = Version.objects.active()
-        context["current_release"] = True
-        return context
-
-    def get_object(self):
-        return Version.objects.most_recent()
-
-
 class VersionDetail(DetailView):
     """Web display of list of Versions"""
 
@@ -29,7 +12,20 @@ class VersionDetail(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
+        context["versions"] = Version.objects.active()
         current_version = Version.objects.most_recent()
         obj = self.get_object()
         context["current_release"] = bool(current_version == obj)
         return context
+
+
+class VersionCurrentReleaseDetail(VersionDetail):
+    """Web display of list of Versions"""
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+        context["current_release"] = True
+        return context
+
+    def get_object(self):
+        return Version.objects.most_recent()

--- a/versions/views.py
+++ b/versions/views.py
@@ -1,22 +1,44 @@
-from django.views.generic import DetailView
+import structlog
 
+from django.views.generic import DetailView
+from django.views.generic.edit import FormMixin
+from django.shortcuts import redirect
+
+from libraries.forms import VersionSelectionForm
 from versions.models import Version
 
+logger = structlog.get_logger(__name__)
 
-class VersionDetail(DetailView):
+
+class VersionDetail(FormMixin, DetailView):
     """Web display of list of Versions"""
 
+    form_class = VersionSelectionForm
     model = Version
     queryset = Version.objects.active()
     template_name = "versions/detail.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
-        context["versions"] = Version.objects.active()
+        context["versions"] = Version.objects.active().order_by("-release_date")
         current_version = Version.objects.most_recent()
         obj = self.get_object()
         context["current_release"] = bool(current_version == obj)
+
         return context
+
+    def post(self, request, *args, **kwargs):
+        """User has submitted a form and will be redirected to the right record."""
+        form = self.get_form()
+        if form.is_valid():
+            version = form.cleaned_data["version"]
+            return redirect(
+                "release-detail",
+                slug=version.slug,
+            )
+        else:
+            logger.info("version_detail_invalid_version")
+        return super().get(request)
 
 
 class VersionCurrentReleaseDetail(VersionDetail):


### PR DESCRIPTION
Closes #492 

- Makes the release selection form on the releases page work, so the drop-down menu can be used to navigate to other releases 