### PR TITLE
Add live docs link to Releases page 

### DIFF
--- a/stage_static_config.json
+++ b/stage_static_config.json
@@ -28,6 +28,10 @@
     "s3_path": "/site-pages/develop/help.adoc"
   },
   {
+    "site_path": "/doc/libs/",
+    "s3_path": "/archives/"
+  },
+  {
     "site_path": "/",
     "s3_path": "/site/develop/"
   }

--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -38,10 +38,10 @@
         <span class="block px-2 pb-1 font-bold">{{ version.release_date|date:"F j, Y" }}</span>
 
         <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-slate"
-           href="https://github.com/boostorg/smart_ptr">
+           href="{{ version.documentation_url }}">
 
           <span class="dark:text-white text-slate">Documentation</span>
-          <span class="block text-xs">boost.revsys.dev/doc/libs/1_81_0/</span>
+          <span class="block text-xs">{{ request.scheme }}://{{ request.get_host }}{{ version.documentation_url|cut:"https://"|cut:"index.html" }}</span>
         </a>
 
         <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-slate"

--- a/versions/models.py
+++ b/versions/models.py
@@ -64,6 +64,16 @@ class Version(models.Model):
             formatted_slug = self.slug
         return formatted_slug
 
+    @cached_property
+    def documentation_url(self):
+        """Return the URL path to documentation for this version of Boost.
+        This maps to the appropriate directory in the S3 bucket. See the
+        static content config file for the mapping from the site_path to the
+        S3 path."""
+        site_path = "/doc/libs/"
+        slug = self.slug.replace("-", "_").replace(".", "_")
+        return f"{site_path}{slug}/index.html"
+
 
 class VersionFile(models.Model):
     Unix = "Unix"

--- a/versions/tests/test_models.py
+++ b/versions/tests/test_models.py
@@ -47,5 +47,11 @@ def test_version_display_name(version):
     assert version.display_name == "1.79.0"
 
 
+def test_version_documentation_url(version):
+    version.slug = "boost-1.81.0"
+    version.save()
+    assert version.documentation_url == "/doc/libs/boost_1_81_0/index.html"
+
+
 def test_version_file_creation(full_version_one):
     assert full_version_one.files.count() == 3


### PR DESCRIPTION
Closes #499

In this PR: 

- New method in Version model for generating a link to older release's docs 
- Adds the docs `site_path` to the S3 static content map, so the URL generated in the Version method points to S3 
- Updates the template 

Result: 

<img width="393" alt="Screenshot 2023-07-11 at 7 01 24 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/f120befd-1dd1-496f-b614-89ff6635da87">
