### PR TITLE
MAILGUN_API_KEY in values.yaml files

### DIFF
--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -120,6 +120,11 @@ Env:
       secretKeyRef:
         name: static-content
         key: bucket_name
+  - name: MAILGUN_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: mailgun
+        key: key
   # Static content cache timeout
   - name: STATIC_CACHE_TIMEOUT
     value: "60"

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -120,6 +120,11 @@ Env:
       secretKeyRef:
         name: static-content
         key: bucket_name
+  - name: MAILGUN_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: mailgun
+        key: key
   # Static content cache timeout
   - name: STATIC_CACHE_TIMEOUT
     value: "60"

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -120,6 +120,11 @@ Env:
       secretKeyRef:
         name: static-content
         key: bucket_name
+  - name: MAILGUN_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: mailgun
+        key: key
   # Static content cache timeout
   - name: STATIC_CACHE_TIMEOUT
     value: "60"


### PR DESCRIPTION
@frankwiles, Copying MAILGUN_API_KEY to the other values.yaml files. Future changes in kube, or github actions, could be done in all the values.yaml / actions.yml files so they propagate to all environments. (Or, chat about it).