### PR TITLE
GITHUB_TOKEN variable in kube

### DIFF
--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -125,6 +125,11 @@ Env:
       secretKeyRef:
         name: mailgun
         key: key
+  - name: GITHUB_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: githubtoken
+        key: key
   # Static content cache timeout
   - name: STATIC_CACHE_TIMEOUT
     value: "60"

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -125,6 +125,11 @@ Env:
       secretKeyRef:
         name: mailgun
         key: key
+  - name: GITHUB_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: githubtoken
+        key: key
   # Static content cache timeout
   - name: STATIC_CACHE_TIMEOUT
     value: "60"

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -125,6 +125,11 @@ Env:
       secretKeyRef:
         name: mailgun
         key: key
+  - name: GITHUB_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: githubtoken
+        key: key
   # Static content cache timeout
   - name: STATIC_CACHE_TIMEOUT
     value: "60"

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -126,6 +126,11 @@ Env:
       secretKeyRef:
         name: mailgun
         key: key
+  - name: GITHUB_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: githubtoken
+        key: key
   # Static content cache timeout
   - name: STATIC_CACHE_TIMEOUT
     value: "60"


### PR DESCRIPTION
Add a GITHUB_TOKEN variable in the kube files.

Depends on a secret "githubtoken" existing in the namespace. _Create the secret before merging the PR._ I've added it to the other namespaces already. Any github user token will work as long as it authenticates the user and thus allows a higher api rate limit. We have a cppalliance-bot account for CI and use that token.  