### PR TITLE
Correct the "Newest Release" message in the drop-down

### DIFF
--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -11,7 +11,7 @@
       <div class="flex-auto mb-2 w-full">
         <div>
 
-            <span class="text-xl md:text-3xl lg:text-4xl">{% if current_release %}Newest {% else %}Prior {% endif %}Release </span>
+            <span class="text-xl md:text-3xl lg:text-4xl">{% if is_current_release %}Newest {% else %}Prior {% endif %}Release </span>
             <span class="text-lg whitespace-nowrap md:text-xl lg:text-3xl pr-[1vw]">({{ version.display_name }})</span>
           <img src="{% static 'img/fpo/boost-release-package.png' %}" class="inline w-8 h-auto" alt="Boost Release Package"/>
         </div>
@@ -26,9 +26,8 @@
                   class="py-1 mb-3 text-sm bg-white rounded-md border border-gray-300 cursor-pointer dark:bg-black pr-[1vw] pl-[2vw] w-[20vw] text-sky-600 dark:text-orange dark:border-slate"
                   id="id_version"
           >
-            <option>Newest Version ({{ version.display_name }})</option>
             {% for v in versions %}
-              <option value="{{ v.pk }}" {% if version == v %}selected="selected"{% endif %}>{{ v.display_name }}</option>
+              <option value="{{ v.pk }}" {% if version == v %}selected="selected"{% endif %}>{% if v == current_release %}Newest Release ({{ v.display_name }}) {% else %}{{ v.display_name }}{% endif %}</option>
             {% endfor %}
           </select>
         </div>

--- a/versions/views.py
+++ b/versions/views.py
@@ -21,9 +21,10 @@ class VersionDetail(FormMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
         context["versions"] = Version.objects.active().order_by("-release_date")
-        current_version = Version.objects.most_recent()
+        current_release = Version.objects.most_recent()
+        context["current_release"] = current_release
         obj = self.get_object()
-        context["current_release"] = bool(current_version == obj)
+        context["is_current_release"] = bool(current_release == obj)
 
         return context
 
@@ -46,7 +47,7 @@ class VersionCurrentReleaseDetail(VersionDetail):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
-        context["current_release"] = True
+        context["is_current_release"] = True
         return context
 
     def get_object(self):


### PR DESCRIPTION
Part of #524 

> After running import_versions, go to /releases/ page, select another version (let's say 1.75.0) in the drop-down, then it shows in the drop-down (Newest Version (1.75.0), which is wrong, because 1.75.0 is not the newest version. 

This PR addresses that bug. 