### PR TITLE
Fix bugs in the library, version, and library-version load scripts 

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -184,14 +184,20 @@ Output:
     Skipping boost-1.82.0.beta1, not a full release
     Saved version boost-1.81.0. Created: True
     Skipping boost-1.81.0.beta1, not a full release
-    tag_not_found
-    {"message": "tag_not_found", "tag_name": "boost-1.80.0", "repo_slug": "boost", "logger": "libraries.github", "level": "info", "timestamp": "2023-05-12T22:14:08.721270Z"}
+    release_by_tag_not_found
+    {"message": "release_by_tag_not_found", "tag_name": "boost-1.80.0", "repo_slug": "boost", "logger": "libraries.github", "level": "info", "timestamp": "2023-05-12T22:14:08.721270Z"}
     ...
     Saved library version Math (boost-1.82.0). Created: True
     Saved library version Xpressive (boost-1.82.0). Created: True
     Saved library version Dynamic Bitset (boost-1.82.0). Created: True
     Saved library version Multi-Index (boost-1.82.0). Created: True
     ...
+
+**What does the `release_by_tag_not_found` error mean?**
+
+When importing the Boost releases, we first get a list of all the tags for the Boost repo. Then, we call the GitHub API's `get_release_by_tag` API to get metadata about the release. But not all Boost tags are also full releases. In this case, we call the `get_commit` endpoint with the commit SHA of the tag to get this information. We could call `get_commit` in every case, but the data in `get_release_by_tag` is more accurate, particularly for the release date.
+
+When we don't find the release in `get_release_by_tag`, we log the error (which is what you may see in the output), but we follow up by getting the data from the commit endpoint.
 
 
 ## `update_libraries`

--- a/libraries/github.py
+++ b/libraries/github.py
@@ -342,7 +342,7 @@ class GithubAPIClient:
 
         return results
 
-    def get_tag_by_name(self, tag_name: str, repo_slug: str = None) -> dict:
+    def get_release_by_tag(self, tag_name: str, repo_slug: str = None) -> dict:
         """Get a tag by name from the GitHub API."""
         if not repo_slug:
             repo_slug = self.repo_slug
@@ -351,7 +351,10 @@ class GithubAPIClient:
                 owner=self.owner, repo=repo_slug, tag=tag_name
             )
         except Exception:
-            logger.info("tag_not_found", tag_name=tag_name, repo_slug=repo_slug)
+            # Not necessarily an error, so log it but don't raise.
+            logger.info(
+                "release_by_tag_not_found", tag_name=tag_name, repo_slug=repo_slug
+            )
             return
 
     def get_tags(self, repo_slug: str = None) -> dict:

--- a/versions/management/commands/import_versions.py
+++ b/versions/management/commands/import_versions.py
@@ -82,12 +82,16 @@ def command(
             click.echo(f"Skipping {name}, not a full release")
             continue
 
-        tag_data = client.get_tag_by_name(name)
+        # Get the metadata about the release from Github
 
         version_data = None
         parser = GithubDataParser()
+
+        # Try to get the metadata about the release from the tag
+        tag_data = client.get_release_by_tag(name)
         if tag_data:
-            # This is a tag and a release, so the metadata is in the tag itself
+            # This is a tag and a release, so the metadata is in the tag itself and
+            # we can parse the data we already have
             version_data = parser.parse_tag(tag_data)
         else:
             # This is a tag, but not a release, so the metadata is in the commit


### PR DESCRIPTION
Part of #524  

- `import_library_versions`: "This crashes at hana in boost version 1.65.0. See note 2 below." -- I am not sure why, but for the Hana library for version 1.65.0, the `submodule` field from the `.gitmodules` entry for that library does not work to retrieve the repo data, but using the `url` field from the `.gitmodules` file does. There aren't obvious differences for `hana` for 1.65.0 vs other versions, that I can see. I caught the error and changed the command to try again with the other field, then edited the script to more gracefully handle it when data isn't found. 
- As part of debugging this, I realized there is an error with 1.61.0, where its `.gitmodules` file can't be accessed at all. That failure is now handled gracefully, but needs to be debugged more fully. 
- Documented an error message raised in #524 