### PR TITLE
Modernize legacy doc libs pages fetched directly from S3.

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -15,6 +15,7 @@ from ak.views import (
 )
 from core.views import (
     ClearCacheView,
+    DocLibsTemplateView,
     MarkdownTemplateView,
     StaticContentTemplateView,
     antora_footer_view,
@@ -261,6 +262,12 @@ urlpatterns = (
     ]
     + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     + [
+        # Libraries docs, some HTML parts are re-written
+        re_path(
+            r"^docs/libs/(?P<content_path>.+)/?",
+            DocLibsTemplateView.as_view(),
+            name="docs-libs-page",
+        ),
         # Markdown content
         re_path(
             r"^markdown/(?P<content_path>.+)/?",

--- a/core/boostrenderer.py
+++ b/core/boostrenderer.py
@@ -26,6 +26,7 @@ def extract_file_data(response, s3_key):
     last_modified = response["LastModified"]
     return {
         "content": file_content,
+        "content_key": s3_key,
         "content_type": content_type,
         "last_modified": last_modified,
     }
@@ -75,8 +76,7 @@ def get_content_from_s3(key=None, bucket_name=None):
 
         # Handle URLs that are directories looking for `index.html` files
         if s3_key.endswith("/"):
-            original_key = s3_key.lstrip("/")
-            index_html_key = f"{original_key}index.html"
+            index_html_key = f"{s3_key}index.html"
             file_data = get_file_data(client, bucket_name, index_html_key)
             if file_data:
                 return file_data

--- a/core/htmlhelper.py
+++ b/core/htmlhelper.py
@@ -1,0 +1,140 @@
+from bs4 import BeautifulSoup
+
+
+# List HTML elements (with relevant attributes) to remove the FIRST occurrence
+REMOVE_TAGS = [
+    # Remove custom headers, these vary from lib to lib, it's usually a table
+    # /docs/libs/1_82_0/ (maps to index.html and has removable headers)
+    (
+        "table",
+        {
+            "bgcolor": "#D7EEFF",
+            "border": "0",
+            "bordercolor": "#111111",
+            "cellpadding": "5",
+            "cellspacing": "0",
+            "style": "border-collapse: collapse",
+        },
+    ),
+    # /doc/libs/1_82_0/libs/functional/index.html
+    # /doc/libs/1_82_0/libs/functional/negators.html
+    # /doc/libs/1_82_0/libs/functional/ptr_fun.html
+    # /doc/libs/1_82_0/libs/functional/function_traits.html
+    # /doc/libs/1_82_0/libs/functional/mem_fun.html
+    # /doc/libs/1_82_0/libs/functional/binders.html
+    # /doc/libs/1_82_0/libs/uuid/doc/index.html
+    # /doc/libs/1_82_0/libs/rational/index.html
+    # /doc/libs/1_82_0/libs/format/index.html
+    ("table", {"bgcolor": "#007F7F", "border": "1", "cellpadding": "2"}),
+    # /docs/libs/1_82_0/libs/multi_array/doc/index.html (lowercase)
+    ("table", {"bgcolor": "#007f7f", "border": "1", "cellpadding": "2"}),
+    # /docs/libs/1_82_0/libs/gil/doc/html/index.html
+    (
+        "table",
+        {
+            "summary": "header",
+            "width": "100%",
+            "cellspacing": "0",
+            "cellpadding": "7",
+            "border": "0",
+        },
+    ),
+    # very prominent header
+    # /docs/libs/1_82_0/libs/locale/doc/html/index.html
+    ("div", {"id": "top"}),
+    # almost every other page has this as a header
+    ("table", {"cellpadding": "2", "width": "100%"}),
+]
+
+# List HTML elements (with relevant attributes) to remove ALL occurrences
+REMOVE_ALL = [
+    # the legacy logo referenced from multiple pages at different depths
+    ("img", {"src": "../../../../boost.png"}),
+    ("img", {"src": "../../../boost.png"}),
+    ("img", {"src": "../../boost.png"}),
+    ("img", {"src": "../boost.png"}),
+    ("img", {"src": "boost.png"}),
+    ("img", {"src": "images/boost.png"}),
+    # These are navigation controls, like next/up/prev. Do not remove for now.
+    # most pages, e.g. /docs/libs/1_82_0/libs/iterator/doc/html/index.html
+    # ("div", {"class": "spirit-nav"}),
+    # /docs/libs/1_82_0/libs/gil/doc/html/index.html
+    # ("div", {"class": "navbar"}),
+    # /docs/libs/1_82_0/libs/iostreams/doc/guide/generic_streams.html
+    # ("div", {"class": "nav"}),
+]
+
+# List HTML elements (with relevant attributes) to remove ONLY their CSS class
+REMOVE_CSS_CLASSESS = [
+    # /docs/libs/1_55_0/libs/exception/doc/boost_exception_all_hpp.html
+    ("div", {"class": "body-0"}),
+    ("div", {"class": "body-1"}),
+    ("div", {"class": "body-2"}),
+    # /docs/libs/1_82_0/libs/numeric/conversion/doc/html/index.html
+    ("div", {"class": "toc"}),
+    ("dl", {"class": "toc"}),
+]
+
+
+def modernize_legacy_page(content, base_html):
+    result = BeautifulSoup(content, "html.parser")
+    if result.html is None:
+        # Not an HTML file we care about
+        return content
+
+    # Remove the first occurrence of legacy header(s) and other stuff
+    for tag_name, tag_attrs in REMOVE_TAGS:
+        tag = result.find(tag_name, tag_attrs)
+        if tag:
+            tag.decompose()
+
+    # Remove all navbar-like divs, if any
+    for tag_name, tag_attrs in REMOVE_ALL:
+        for tag in result.find_all(tag_name, tag_attrs):
+            tag.decompose()
+
+    # Remove CSS classes that produce visual harm
+    for tag_name, tag_attrs in REMOVE_CSS_CLASSESS:
+        for tag in result.find_all(tag_name, tag_attrs):
+            tag.attrs.pop("class")
+
+    # Use the base HTML to later extract the <head> and (part of) the <body>
+    placeholder = BeautifulSoup(base_html, "html.parser")
+
+    # Append the <head> taken from the base HTML to the existing (legacy) head
+    if placeholder.head is not None:
+        to_add = [
+            BeautifulSoup("<!-- BEGIN Manually appending head -->"),
+            placeholder.head,
+            BeautifulSoup("<!-- END Manually appending head -->"),
+        ]
+        if result.head is None:
+            for i in reversed(to_add):
+                result.html.insert(0, i)
+        else:
+            for i in to_add:
+                result.head.append(i)
+            result.head.head.unwrap()
+
+    # Beautify the legacy body with structure and classes from the new one, and
+    # embed the original body into an "<div id="boost-legacy-body"> element
+    original_body = result.body
+    if original_body is not None and placeholder.body is not None:
+        base_body_content = placeholder.body.find("div", {"id": "boost-legacy-body"})
+        to_add = [
+            BeautifulSoup("<!-- BEGIN Manually appending body -->"),
+            original_body,
+            BeautifulSoup("<!-- END Manually appending body -->"),
+        ]
+        if base_body_content is not None:
+            result.body.replace_with(placeholder.body)
+            for i in to_add:
+                base_body_content.append(i)
+            result.body.body.unwrap()
+
+    content = result.prettify()
+
+    # Replace all links to boost.org with a local link
+    content = content.replace("https://www.boost.org/doc/libs/", "/docs/libs/")
+
+    return content

--- a/core/tests/fixtures.py
+++ b/core/tests/fixtures.py
@@ -10,3 +10,28 @@ def rendered_content(db):
         content_original="Sample content",
         content_html="<p>Sample content</p>",
     )
+
+
+@pytest.fixture
+def mock_get_file_data(monkeypatch):
+    def _mock_get_file_data(
+        content,
+        content_s3_key,
+        content_s3_key_prefix="/archives/",
+        content_type="text/html",
+    ):
+        def get_file_data(client, bucket_name, s3_key):
+            if f"{content_s3_key_prefix}{content_s3_key}" == s3_key:
+                result = {
+                    "content": content,
+                    "content_key": s3_key,
+                    "content_type": content_type,
+                    "last_modified": None,
+                }
+            else:
+                result = None
+            return result
+
+        monkeypatch.setattr("core.boostrenderer.get_file_data", get_file_data)
+
+    return _mock_get_file_data

--- a/core/tests/test_htmlhelper.py
+++ b/core/tests/test_htmlhelper.py
@@ -1,0 +1,300 @@
+import pytest
+from pytest_django.asserts import assertHTMLEqual
+
+from core.htmlhelper import (
+    REMOVE_ALL,
+    REMOVE_CSS_CLASSESS,
+    REMOVE_TAGS,
+    modernize_legacy_page,
+)
+
+
+BASE_HEAD = """
+    <link rel="stylesheet" href="mystyle.css" />
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <style>
+      body {background-color: powderblue;}
+      h1 {color: red;}
+      p {color: blue;}
+    </style>
+    <meta name="description" content="Unit Test" />
+    <meta name="keywords" content="HTML, CSS, JavaScript" />
+"""
+BASE_TOKEN = "<!-- Add your content here -->"
+BASE_BODY = f"""
+    <h1>A very important heading</h1>
+    <p>My first paragraph.</p>
+    <div id="other-block-content-id">
+      <p>My second paragraph.</p>
+    </div>
+    <div id="boost-legacy-body">
+      {BASE_TOKEN}
+    </div>
+"""
+BASE_HTML = f"""<!DOCTYPE html>
+    <head>{BASE_HEAD}</head>
+    <html>
+    <body>{BASE_BODY}</body>
+    </html>
+"""
+LEGACY_HEAD = """
+    <title>A Meaningful Page Title</title>
+    <link rel="stylesheet" href="old.css" />
+"""
+LEGACY_BODY = """
+   <h1>My Legacy Heading</h1>
+   <p>My legacy paragraph.</p>
+"""
+
+
+def _build_tag(tag_name, tag_attrs, inner="Something"):
+    return (
+        f"<{tag_name}"
+        + (" " if tag_attrs else "")
+        + " ".join(f'{k}="{v}"' for k, v in tag_attrs.items())
+        + (f">{inner}</{tag_name}>" if tag_name != "img" else "/>")
+    )
+
+
+def _build_expected_body(expected_body):
+    return BASE_BODY.replace(
+        BASE_TOKEN,
+        f"""
+        {BASE_TOKEN}
+        {expected_body}
+        """,
+    )
+
+
+def test_modernize_legacy_page_unchanged_empty():
+    original = """Something else"""
+
+    result = modernize_legacy_page(original, base_html=BASE_HTML)
+
+    assertHTMLEqual(result, original)
+
+
+def test_modernize_legacy_page_unchanged_simple():
+    original = """<!DOCTYPE html>
+    <html>
+    </html>
+    """
+
+    result = modernize_legacy_page(original, base_html="")
+
+    assertHTMLEqual(result, original)
+
+
+def test_modernize_legacy_page_unchanged_no_head():
+    original = f"""<!DOCTYPE html>
+    <html>
+    <body>
+    {LEGACY_BODY}
+    </body>
+    </html>
+    """
+
+    result = modernize_legacy_page(original, base_html="")
+
+    assertHTMLEqual(result, original)
+
+
+def test_modernize_legacy_page_unchanged_no_body():
+    original = f"""<!DOCTYPE html>
+    <head>
+    {LEGACY_HEAD}
+    </head>
+    <html>
+    </html>
+    """
+
+    result = modernize_legacy_page(original, base_html="")
+
+    assertHTMLEqual(result, original)
+
+
+def test_modernize_legacy_page_adds_head_if_missing():
+    original = """<!DOCTYPE html>
+    <html>
+    </html>
+    """
+
+    result = modernize_legacy_page(original, base_html=BASE_HTML)
+
+    expected = f"""<!DOCTYPE html>
+    <html>
+    <head>
+      <!-- BEGIN Manually appending head -->
+      {BASE_HEAD}
+      <!-- END Manually appending head -->
+    </head>
+    </html>
+    """
+    assertHTMLEqual(result, expected)
+
+
+def test_modernize_legacy_page_appends_head_if_existing():
+    original = f"""<!DOCTYPE html>
+    <html>
+    <head>
+    {LEGACY_HEAD}
+    </head>
+    </html>
+    """
+
+    result = modernize_legacy_page(original, base_html=BASE_HTML)
+
+    expected = f"""<!DOCTYPE html>
+    <html>
+    <head>
+      {LEGACY_HEAD}
+      <!-- BEGIN Manually appending head -->
+      {BASE_HEAD}
+      <!-- END Manually appending head -->
+    </head>
+    </html>
+    """
+    assertHTMLEqual(result, expected)
+
+
+def test_modernize_legacy_page_mangles_body():
+    original = f"""<!DOCTYPE html>
+    <html>
+    <body>
+    {LEGACY_BODY}
+    </body>
+    </html>
+    """
+
+    result = modernize_legacy_page(original, base_html=BASE_HTML)
+
+    expected = f"""<!DOCTYPE html>
+    <html>
+    <head>
+      <!-- BEGIN Manually appending head -->
+      {BASE_HEAD}
+      <!-- END Manually appending head -->
+    </head>
+    <body>
+      {_build_expected_body(LEGACY_BODY)}
+    </body>
+    </html>
+    """
+    assertHTMLEqual(result, expected)
+
+
+@pytest.mark.parametrize("tag_name, tag_attrs", REMOVE_TAGS)
+def test_modernize_legacy_page_remove_first_tag_found(tag_name, tag_attrs):
+    tag = _build_tag(tag_name, tag_attrs)
+
+    original = f"""<!DOCTYPE html>
+    <html>
+    <body>
+      <h1>My Legacy Heading</h1>
+      {tag}
+      <p>My legacy paragraph.</p>
+      {tag}
+    </body>
+    </html>
+    """
+
+    result = modernize_legacy_page(original, base_html=BASE_HTML)
+
+    body = _build_expected_body(LEGACY_BODY + tag)
+    expected = f"""<!DOCTYPE html>
+    <html>
+    <head>
+      <!-- BEGIN Manually appending head -->
+      {BASE_HEAD}
+      <!-- END Manually appending head -->
+    </head>
+    <body>
+      {body}
+    </body>
+    </html>
+    """
+    assertHTMLEqual(result, expected)
+
+
+@pytest.mark.parametrize("tag_name, tag_attrs", REMOVE_ALL)
+def test_modernize_legacy_page_remove_all_tags_found(tag_name, tag_attrs):
+    tag = _build_tag(tag_name, tag_attrs)
+
+    original = f"""<!DOCTYPE html>
+    <html>
+    <body>
+      {tag}
+      <h1>My Legacy Heading</h1>
+      {tag}
+      <p>My legacy paragraph.</p>
+      {tag}
+    </body>
+    </html>
+    """
+
+    result = modernize_legacy_page(original, base_html=BASE_HTML)
+
+    expected = f"""<!DOCTYPE html>
+    <html>
+    <head>
+      <!-- BEGIN Manually appending head -->
+      {BASE_HEAD}
+      <!-- END Manually appending head -->
+    </head>
+    <body>
+      {_build_expected_body(LEGACY_BODY)}
+    </body>
+    </html>
+    """
+    assertHTMLEqual(result, expected)
+
+
+@pytest.mark.parametrize("tag_name, tag_attrs", REMOVE_CSS_CLASSESS)
+def test_modernize_legacy_page_remove_only_css_class(tag_name, tag_attrs):
+    tag_attrs = tag_attrs.copy()
+    tag_attrs.setdefault("class", "something-to-remove")
+    tag = _build_tag(tag_name, tag_attrs)
+
+    original = f"""<!DOCTYPE html>
+    <html>
+    <body>
+      {tag}
+      <h1 class="some-class">My Legacy Heading</h1>
+      {tag}
+      <p>My legacy paragraph.</p>
+      {tag}
+      <div class="not-a-match"><p>Hello World</p></div>
+      {tag}
+    </body>
+    </html>
+    """
+
+    result = modernize_legacy_page(original, base_html=BASE_HTML)
+
+    # Build expected result
+    tag_attrs.pop("class")
+    tag_without_class = _build_tag(tag_name, tag_attrs)
+    expected_body = f"""
+      {tag_without_class}
+      <h1 class="some-class">My Legacy Heading</h1>
+      {tag_without_class}
+      <p>My legacy paragraph.</p>
+      {tag_without_class}
+      <div class="not-a-match"><p>Hello World</p></div>
+      {tag_without_class}
+    """
+    body = _build_expected_body(expected_body)
+    expected = f"""<!DOCTYPE html>
+    <html>
+    <head>
+      <!-- BEGIN Manually appending head -->
+      {BASE_HEAD}
+      <!-- END Manually appending head -->
+    </head>
+    <body>
+      {body}
+    </body>
+    </html>
+    """
+    assertHTMLEqual(result, expected)

--- a/core/tests/test_renderer.py
+++ b/core/tests/test_renderer.py
@@ -27,6 +27,7 @@ def test_extract_file_data():
 
     expected_result = {
         "content": b"file content",
+        "content_key": s3_key,
         "content_type": "text/plain",
         "last_modified": datetime.datetime(2023, 6, 8, 12, 0, 0),
     }

--- a/stage_static_config.json
+++ b/stage_static_config.json
@@ -1,5 +1,9 @@
 [
   {
+    "site_path": "/archives/",
+    "s3_path": "/archives/"
+  },
+  {
     "site_path": "/doc/user-guide/",
     "s3_path": "/site-docs/develop/user-guide/"
   },

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,21 +23,21 @@
     </script>
 
     <title>{% block title %}Boost{% endblock %}</title>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="{% block description %}{% endblock %}">
-    <meta name="keywords" content="{% block keywords %}{% endblock %}">
-    <meta name="author" content="{% block author %}{% endblock %}">
-    <link rel="shortcut icon" href="{% static 'img/Boost_Symbol_Transparent.svg' %}" type="image/x-icon">
-    <link href="{% static 'css/styles.css' %}" rel="stylesheet">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="{% block description %}{% endblock %}" />
+    <meta name="keywords" content="{% block keywords %}{% endblock %}" />
+    <meta name="author" content="{% block author %}{% endblock %}" />
+    <link rel="shortcut icon" href="{% static 'img/Boost_Symbol_Transparent.svg' %}" type="image/x-icon" />
+    <link href="{% static 'css/styles.css' %}" rel="stylesheet" />
 
     <meta class="meta-theme" name="theme-color" content="#FAFAFA" data-dark="#18181B" data-light="#FAFAFA" />
     <meta class="meta-theme" name="color-scheme" content="light" data-dark="dark" data-light="light" />
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.css" />
     {% comment %}just testing out boxicons for quick animations on hover (add bx-tada-hover, bx-burst-hover, etc as classes){% endcomment %}
-    <link href="https://unpkg.com/boxicons@2.1.1/css/boxicons.min.css" rel="stylesheet">
+    <link href="https://unpkg.com/boxicons@2.1.1/css/boxicons.min.css" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/@ryangjchandler/alpine-clipboard@2.x.x/dist/alpine-clipboard.js" defer></script>
     <script src="//unpkg.com/alpinejs" defer></script>
     <script src="https://unpkg.com/htmx.org@1.8.5" integrity="sha384-7aHh9lqPYGYZ7sTHvzP1t3BAfLhYSTy9ArHdP3Xsr9/3TlGurYgcPBoFmXX2TX/w" crossorigin="anonymous"></script>

--- a/templates/docs_libs_placeholder.html
+++ b/templates/docs_libs_placeholder.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block extra_head %}
+  {% comment %}
+   These style tweaks ensure that legacy doc pages are rendered decently.
+   Specifically, the <img> tag is heavily used in nav bar for tutorial navigation.
+  {% endcomment %}
+  <style>
+    img {
+      display: inline-block;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+    <div id="boost-legacy-body">
+    </div>
+    {% if legacy_url %}
+    <a id="boost-legacy-url" href="{{ legacy_url }}">
+      <small>Legacy page</small>
+    </a>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
This modernization occurs on the fly over potentially-cached S3 files. This
means, the legacy doc pages are fetched and cached just like any other S3
static content, and the modernization happens when the page is requested.
This way, we can safely render modern parts of the pages (like the header)
and account for dynamic state such as logged in users.
    
The resulting docs (also called FrankenDocs :-)) are processed using
BeautifulSoup and a fairly simple heuristic that can be found in the
`core/htmlhelper.py` module.

Fixes #534.