### PR TITLE
Move /doc/ site_path lower down

### DIFF
--- a/stage_static_config.json
+++ b/stage_static_config.json
@@ -1,9 +1,5 @@
 [
   {
-    "site_path": "/doc/",
-    "s3_path": "/site-docs/develop/"
-  },
-  {
     "site_path": "/doc/user-guide/",
     "s3_path": "/site-docs/develop/user-guide/"
   },
@@ -30,6 +26,10 @@
   {
     "site_path": "/doc/libs/",
     "s3_path": "/archives/"
+  },
+  {
+    "site_path": "/doc/",
+    "s3_path": "/site-docs/develop/"
   },
   {
     "site_path": "/",


### PR DESCRIPTION
Moves the `/doc/` site_path lower down to allow more specific/more accurate paths to show up first in the list of s3 keys. 

@nessita As far as I can tell, this change retains the fix I made for https://github.com/cppalliance/temp-site/issues/255 but should address the issue we discussed where less-specific (and therefore bad) paths were showing up first! 

Example with new order: 

```
In [1]: key='/doc/libs/boost_1_48_0/doc/html/accumulators/acknowledgements.html'

In [2]: from core.boostrenderer import get_s3_keys

In [3]: get_s3_keys(key)
Out[3]: 
['/archives/boost_1_48_0/doc/html/accumulators/acknowledgements.html',
 '/site-docs/develop/libs/boost_1_48_0/site-docs/develop/html/accumulators/acknowledgements.html',
 '/site/develop/doc/libs/boost_1_48_0/doc/html/accumulators/acknowledgements.html']
```