### PR TITLE
Skip time-consuming github data for local dev

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -212,4 +212,6 @@ Synced information:
 - Library categories are updated, if need be.
 - Issues and Pull Requests are synced
 
-**NOTE**: Can take upwards of a half hour to run. If you are trying to populate tables for local development, `create_sample_data` is a better option if the GitHub integrations aren't important.
+**For local development**: Run with the `--local` flag. This skips pulling Issues and Pull Requests data, Commit history, and other data that takes a long time to run.
+
+**NOTE**: Can take upwards of a half hour to run if the `--local` flag is not passed.

--- a/libraries/github.py
+++ b/libraries/github.py
@@ -636,8 +636,16 @@ class LibraryUpdater:
 
         return libraries
 
-    def update_libraries(self, since: datetime = None, until: datetime = None):
-        """Update all libraries with the metadata"""
+    def update_libraries(
+        self,
+        since: datetime = None,
+        until: datetime = None,
+        update_monthly_commit_counts: bool = True,
+        update_first_tag_date: bool = True,
+    ):
+        """
+        Update all libraries with the metadata from their libraries.json file.
+        """
         raw_gitmodules = self.client.get_gitmodules()
         gitmodules = self.parser.parse_gitmodules(raw_gitmodules.decode("utf-8"))
         library_data = self.get_library_list(gitmodules=gitmodules)
@@ -650,10 +658,13 @@ class LibraryUpdater:
             obj = self.update_library(lib)
             if not obj:
                 continue
+
             self.update_categories(obj, categories=lib["category"])
             self.update_authors(obj, authors=lib["authors"])
-            self.update_monthly_commit_counts(obj, since=since, until=until)
-            if not obj.first_github_tag_date:
+
+            if update_monthly_commit_counts:
+                self.update_monthly_commit_counts(obj, since=since, until=until)
+            if update_first_tag_date and not obj.first_github_tag_date:
                 self.update_first_github_tag_date(obj)
 
     def update_library(self, library_data: dict) -> Library:

--- a/libraries/management/commands/update_libraries.py
+++ b/libraries/management/commands/update_libraries.py
@@ -4,12 +4,33 @@ from libraries.github import LibraryUpdater
 
 
 @click.command()
-def command():
+@click.option("--local", is_flag=True, default=False)
+@click.option("--update_monthly_commit_counts", is_flag=True, default=True)
+@click.option("--update_first_tag_date", is_flag=True, default=True)
+def command(local, update_monthly_commit_counts, update_first_tag_date):
     """
     Calls the LibraryUpdater, which retrieves the active boost libraries
     from the Boost repo and updates the models in our database with the latest
     information on that library (repo) and its issues, pull requests, and related
     objects from GitHub.
+
+    If the --local flag is set, then the monthly commit counts and first tag date
+    will not be updated. This is useful for testing, since the monthly commit counts
+    and first tag date are not updated very often, and it takes a long time to
+    retrieve them from GitHub.
+
+    If the --update_monthly_commit_counts flag is set, then the monthly commit counts
+    will be updated. This can take a long time.
+
+    If the --update_first_tag_date flag is set, then the first tag date will be updated.
+    This can take a long time.
     """
     updater = LibraryUpdater()
-    updater.update_libraries()
+
+    if local:
+        update_monthly_commit_counts = False
+        update_first_tag_date = False
+    updater.update_libraries(
+        update_monthly_commit_counts=update_monthly_commit_counts,
+        update_first_tag_date=update_first_tag_date,
+    )


### PR DESCRIPTION
Run `./manage.py update_libraries --local` to skip the most time-consuming github data for local dev. Now the command takes a minute or two to run and doesn't rate limit. Will be missing the release date for the library and the monthly commit history. 

FYI @gregnewman @nessita @frankwiles @4down @sdarwin 