### PR TITLE
New single-page profile page: Change password form

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -52,6 +52,7 @@ from support.views import ContactView, SupportView
 from users.views import (
     CurrentUserAPIView,
     CurrentUserProfileView,
+    NewCurrentUserProfileView,
     ProfilePhotoGitHubUpdateView,
     ProfilePhotoUploadView,
     ProfilePreferencesView,
@@ -84,6 +85,11 @@ urlpatterns = (
             "users/me/preferences/",
             ProfilePreferencesView.as_view(),
             name="profile-preferences",
+        ),
+        path(
+            "users/me/new/",
+            NewCurrentUserProfileView.as_view(),
+            name="profile-account-new",
         ),
         path("users/me/", CurrentUserProfileView.as_view(), name="profile-account"),
         # Temp route to prove antora header

--- a/templates/users/profile_base_new.html
+++ b/templates/users/profile_base_new.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% load static %}
+
+{% block subnav %}
+  <div class="flex items-center py-3 px-4 border-b md:px-0 md:border-0 border-slate">
+    <div>
+      {% if user.image %}
+        <img src="{{ user.image.url }}" alt="user" class="inline rounded-lg w-[80px]" />
+      {% else %}
+        <i class="mr-2 text-5xl fas fa-user text-white/60"></i>
+      {% endif %}
+    </div>
+    <div class="ml-4 text-sm">
+      <span class="block">{{ user.get_full_name }}</span>
+      <span class="text-xs text-slate">Joined {{ user.date_joined }}</span>
+    </div>
+  </div>
+  <div class="relative py-8 px-4 space-y-4 text-sm uppercase border-b md:py-2 md:px-0 md:space-x-10 border-slate">
+  </div>
+{% endblock %}

--- a/templates/users/profile_new.html
+++ b/templates/users/profile_new.html
@@ -1,0 +1,61 @@
+{% extends "users/profile_base_new.html" %}
+
+{% load static i18n %}
+
+{% block content %}
+  <div class="py-0 px-3 mb-3 md:flex md:py-6 md:px-0">
+
+    <div class="content-section">
+        <div class="mt-6">
+          <img class="w-32 h-32 rounded-full md:h-auto" src="{{ user.profile.image.url }}">
+        </div>
+
+        <h3>{% trans "Set Password" %}</h3>
+
+        <form method="POST" action="." class="password_set">
+            {% csrf_token %}
+            <fieldset>{{ change_password_form.as_p }}</fieldset>
+            <div class="mb-4">
+                <button name="change_password" class="py-2 px-3 text-sm uppercase rounded border border-orange text-orange" type="submit">Set Password</button>
+            </div>
+        </form>
+
+        <h3>{% trans "Update Profile Photo" %}</h3>
+
+        {% if user.github_username %}
+          <form method="POST" action=".">
+            {% csrf_token %}
+            <button name="update_github_photo" class="py-2 px-3 text-sm uppercase rounded border border-orange text-orange" type="submit">Use My GitHub Photo</button>
+          </form>
+        {% endif %}
+
+        <form method="POST" enctype="multipart/form-data" action=".">
+          {% csrf_token %}
+          <fieldset>
+                {{ profile_photo_form.as_p }}
+          </fieldset>
+          <div class="mb-4">
+              <button name="update_photo" class="py-2 px-3 text-sm uppercase rounded border border-orange text-orange" type="submit">Upload Profile Photo</button>
+          </div>
+      </form>
+
+      <hr />
+      <h3>{% trans "Update Preferences" %}</h3>
+
+      <form method="POST" action=".">
+        {% csrf_token %}
+        <p>Notify me via email when:</p>
+        {{ profile_preferences_form.errors }}
+        <fieldset>
+          {{ profile_preferences_form.as_div }}
+        </fieldset>
+        <div class="mb-4">
+            <button name="update_preferences" class="py-2 px-3 text-sm uppercase rounded border border-orange text-orange" type="submit">Update Preeferences</button>
+        </div>
+      </form>
+    </div>
+
+    </div>
+
+  </div>
+{% endblock %}

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -1,6 +1,12 @@
 import pytest
+import tempfile
 
-from ..forms import PreferencesForm
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from allauth.account.forms import ChangePasswordForm
+from PIL import Image
+
+from ..forms import PreferencesForm, UserProfilePhotoForm
 from ..models import Preferences
 
 
@@ -53,6 +59,125 @@ def test_preferences_post_clears_options(
     ):
         expected = original
     assert getattr(user.preferences, form_field) == expected
+
+    assert_messages(
+        response, [("success", "Your preferences were successfully updated.")]
+    )
+
+
+@pytest.mark.django_db
+def test_new_current_user_profile_not_authenticated(tp, user):
+    tp.assertLoginRequired("profile-account-new")
+
+
+@pytest.mark.django_db
+def test_new_current_user_profile_view_get(user, tp):
+    with tp.login(user):
+        response = tp.assertGoodView(tp.reverse("profile-account-new"), verbose=True)
+        assert isinstance(response.context["change_password_form"], ChangePasswordForm)
+        assert isinstance(response.context["profile_photo_form"], UserProfilePhotoForm)
+        assert isinstance(response.context["profile_preferences_form"], PreferencesForm)
+
+
+@pytest.mark.django_db
+def test_new_current_user_profile_view_post_valid_password(user, tp):
+    with tp.login(user):
+        response = tp.post(
+            tp.reverse("profile-account-new"),
+            data={
+                "email": user.email,
+                "oldpassword": "password",
+                "password1": "new_password",
+                "password2": "new_password",
+            },
+            follow=True,
+        )
+        assert response.status_code == 200
+        user.refresh_from_db()
+        user.check_password("new_password")
+
+
+@pytest.mark.django_db
+def test_new_current_user_profile_view_post_invalid_password(user, tp):
+    old_password = "password"
+    with tp.login(user):
+        response = tp.post(
+            tp.reverse("profile-account-new"),
+            data={
+                "email": user.email,
+                "oldpassword": "not the right password",
+                "password1": "new_password",
+                "password2": "new_password",
+            },
+            follow=True,
+        )
+        assert response.status_code == 200
+        user.refresh_from_db()
+        user.check_password(old_password)
+
+
+@pytest.mark.django_db
+def test_new_current_user_profile_view_post_valid_photo(user, tp):
+    """Test that a user can upload a new profile picture."""
+    # Create a temporary image file for testing
+    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as temp_image:
+        image = Image.new("RGB", (200, 200))
+        image.save(temp_image, "jpeg")
+        temp_image.seek(0)
+
+        # Wrap temp_image in Django's File object
+        uploaded_file = SimpleUploadedFile(
+            name="test_image.jpg", content=temp_image.read(), content_type="image/jpeg"
+        )
+
+    with tp.login(user):
+        response = tp.post(
+            tp.reverse("profile-account-new"),
+            data={
+                "image": uploaded_file,
+            },
+            follow=True,
+        )
+        assert response.status_code == 200
+        user.refresh_from_db()
+        assert user.image
+        # confirm that password was not changed, as these are on the same screen
+        assert user.check_password("password")
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("user_type", ["user", "moderator_user"])
+@pytest.mark.parametrize("form_field", PreferencesForm.Meta.fields)
+def test_new_current_user_profile_view_post_valid_preferences(
+    user_type, form_field, tp, request, assert_messages
+):
+    user = request.getfixturevalue(user_type)
+    original_preferences = {
+        field: getattr(user.preferences, field) for field in PreferencesForm.Meta.fields
+    }
+    new_preferences = {
+        field: [] for field in PreferencesForm.Meta.fields
+    }  # Clear all options
+
+    with tp.login(user):
+        response = tp.post(
+            tp.reverse("profile-account-new"),
+            data={**new_preferences, "update_preferences": "Update Preeferences"},
+            follow=True,
+        )
+
+    assert response.status_code == 200
+    user.refresh_from_db()
+    for field in PreferencesForm.Meta.fields:
+        if (
+            field == "allow_notification_others_news_needs_moderation"
+            and user_type != "moderator_user"
+        ):
+            assert (
+                getattr(user.preferences, field) == original_preferences[field]
+            )  # Field should be unchanged for non-moderators
+        else:
+            assert getattr(user.preferences, field) == []  # Field should be cleared
 
     assert_messages(
         response, [("success", "Your preferences were successfully updated.")]


### PR DESCRIPTION
Adds a new profile update page that puts all forms on a single page per Friday's meeting. 

- Update password (will log you out and force you to log back in with new credentials) 
- Import GH photo (synchronous for now -- there is a bug when it's call async that I'll address in a separate PR) 
- Upload new photo 
- Manage notification preferences 
- Each form submits on its own -- so if I select a new photo to upload AND change my notification preferences, then if I hit the "upload new photo" button, my new preferences **will not** be saved, and vice versa. I can change this, but I didn't want to get too ahead of myself before design had been discussed, so I kept them separate for now. 

in a new URL `/users/me/new/` to retain existing functionality (just in case). 

<img width="942" alt="Screenshot 2023-07-25 at 12 34 16 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/19a873ac-af6e-4063-87cf-ef24a4048cc0">
