### PR TITLE
Truncate hashes

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1229,10 +1229,6 @@ i:not(.link-force) {
   margin-right: -1.5rem;
 }
 
-.mt-1 {
-  margin-top: 0.25rem;
-}
-
 .mt-0 {
   margin-top: 0px;
 }
@@ -1291,6 +1287,10 @@ i:not(.link-force) {
 
 .-ml-2 {
   margin-left: -0.5rem;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
 }
 
 .ml-0 {
@@ -3439,6 +3439,14 @@ i:not(.link-force) {
     margin-bottom: 2.5rem;
   }
 
+  .lg\:block {
+    display: block;
+  }
+
+  .lg\:hidden {
+    display: none;
+  }
+
   .lg\:min-w-\[300px\] {
     min-width: 300px;
   }
@@ -3502,8 +3510,16 @@ i:not(.link-force) {
 }
 
 @media (min-width: 1280px) {
+  .xl\:block {
+    display: block;
+  }
+
   .xl\:inline {
     display: inline;
+  }
+
+  .xl\:hidden {
+    display: none;
   }
 
   .xl\:grid-cols-3 {

--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
+{% load text_helpers %}
 
 {% block title %}{% trans "Releases" %}{% endblock %}
 
@@ -89,7 +90,7 @@
                         </svg>
                       </button>
                     </td>
-                    <td class="bg-gray-100 border border-b-0 border-l-0 border-gray-200 truncCell dark:bg-charcoal" title="{{ download.checksum }}">{{ download.checksum }}</td>
+                    <td class="bg-gray-100 border border-b-0 border-l-0 border-gray-200 truncCell dark:bg-charcoal" title="{{ download.checksum }}">{{ download.checksum|truncate_middle:30 }}</td>
                   </tr>
                 {% endfor %}
               {% endfor %}
@@ -1357,27 +1358,27 @@
 {% endblock %}
 
 {% block footer_js %}
-<script>
-  document.addEventListener('alpine:init', () => {
-    Alpine.data('truncator', () => ({
-      truncation: 0,
-      adjust() {
-        if (this.$root.clientWidth >= this.$root.scrollWidth && this.$root.parentElement.clientWidth >= this.$root.querySelectorAll('table')[0].clientWidth) {
-          this.truncation = 0;
-          this.$el.querySelectorAll(`.truncCell`).forEach((el) => {
-            el.innerHTML = el.title;
-          });
-        }
-        else {
-          while (this.$root.clientWidth < this.$root.scrollWidth || this.$root.parentElement.clientWidth < this.$root.querySelectorAll('table')[0].clientWidth) {
-            this.truncation++;
-            this.$el.querySelectorAll(`.truncCell`).forEach((el) => {
-              el.innerHTML = el.title.substr(0, (el.title.length / 2) - this.truncation) + '&hellip;' + el.title.substr((el.title.length / 2) + this.truncation, el.title.length);
-            });
-          }
-        }
-      },
-    }));
-  });
-</script>
+{#<script>#}
+{#  document.addEventListener('alpine:init', () => {#}
+{#    Alpine.data('truncator', () => ({#}
+{#      truncation: 0,#}
+{#      adjust() {#}
+{#        if (this.$root.clientWidth >= this.$root.scrollWidth && this.$root.parentElement.clientWidth >= this.$root.querySelectorAll('table')[0].clientWidth) {#}
+{#          this.truncation = 0;#}
+{#          this.$el.querySelectorAll(`.truncCell`).forEach((el) => {#}
+{#            el.innerHTML = el.title;#}
+{#          });#}
+{#        }#}
+{#        else {#}
+{#          while (this.$root.clientWidth < this.$root.scrollWidth || this.$root.parentElement.clientWidth < this.$root.querySelectorAll('table')[0].clientWidth) {#}
+{#            this.truncation++;#}
+{#            this.$el.querySelectorAll(`.truncCell`).forEach((el) => {#}
+{#              el.innerHTML = el.title.substr(0, (el.title.length / 2) - this.truncation) + '&hellip;' + el.title.substr((el.title.length / 2) + this.truncation, el.title.length);#}
+{#            });#}
+{#          }#}
+{#        }#}
+{#      },#}
+{#    }));#}
+{#  });#}
+{#</script>#}
 {% endblock %}

--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -90,7 +90,11 @@
                         </svg>
                       </button>
                     </td>
-                    <td class="bg-gray-100 border border-b-0 border-l-0 border-gray-200 truncCell dark:bg-charcoal" title="{{ download.checksum }}">{{ download.checksum|truncate_middle:30 }}</td>
+                    <td class="bg-gray-100 border border-b-0 border-l-0 border-gray-200 truncCell dark:bg-charcoal" title="{{ download.checksum }}">
+                      <span class="hidden xl:block">{{ download.checksum }}</span>
+                      <span class="hidden md:block xl:hidden">{{ download.checksum|truncate_middle:20 }}</span>
+                      <span class="md:hidden">{{ download.checksum|truncate_middle:10 }}</span>
+                    </td>
                   </tr>
                 {% endfor %}
               {% endfor %}


### PR DESCRIPTION
On mobile devices 10 chars
On medium browsers 20 chars
On x-large browser show the whole hash