### PR TITLE
Fix library detail url for older versions

### DIFF
--- a/templates/libraries/_library_list_item.html
+++ b/templates/libraries/_library_list_item.html
@@ -3,7 +3,12 @@
 <div class="relative content-between p-3 bg-white rounded-lg shadow-lg md:p-5 dark:bg-charcoal">
   <div class="">
     <h3 class="pb-2 text-2xl capitalize border-b border-gray-300 dark:border-slate">
-      <a class="link-header" href="{% url 'library-detail' slug=library.slug %}"
+      <a class="link-header" href="
+        {% if version %}
+          {% url 'library-detail-by-version' slug=library.slug version_slug=version.slug %}
+        {% else %}
+          {% url 'library-detail' slug=library.slug %}
+        {% endif %}"
       >{{ library.name }}</a>
       {% for author in library.authors.all %}
         {% if author.image %}


### PR DESCRIPTION
On the library list page, when you select an older version, the links for the libraries don't link to the older version of that library.  https://www.boost.revsys.dev/libraries/?q=&category=&version=boost-1-79-0 