### PR TITLE
Display error message for bad password

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -59,6 +59,7 @@ from users.views import (
     ProfilePreferencesView,
     ProfileView,
     UserViewSet,
+    CustomLoginView,
 )
 from versions.api import VersionViewSet
 from versions.views import VersionCurrentReleaseDetail, VersionDetail
@@ -75,6 +76,7 @@ urlpatterns = (
         path("", HomepageView.as_view(), name="home"),
         path("homepage-beta/", HomepageBetaView.as_view(), name="home-beta"),
         path("admin/", admin.site.urls),
+        path("accounts/login/", CustomLoginView.as_view(), name="account_login"),
         path("accounts/", include("allauth.urls")),
         path(
             "users/me/update-github-photo/",

--- a/users/views.py
+++ b/users/views.py
@@ -9,6 +9,7 @@ from django.views.generic.base import TemplateView
 
 from allauth.account.forms import ChangePasswordForm
 from allauth.socialaccount.models import SocialAccount
+from allauth.account.views import LoginView
 
 from rest_framework import generics
 from rest_framework import viewsets
@@ -233,3 +234,12 @@ class NewCurrentUserProfileView(LoginRequiredMixin, SuccessMessageMixin, Templat
         else:
             for error in form.errors.values():
                 messages.error(request, f"{error}")
+
+
+class CustomLoginView(LoginView):
+    def form_invalid(self, form):
+        # Add form's non-field errors to Django's messages framework
+        for error in form.non_field_errors():
+            messages.error(self.request, error)
+
+        return super().form_invalid(form)


### PR DESCRIPTION
Part of #570: Ensures that error message is displayed when a user enters bad credentials on email login. @frankwiles or @gregnewman wanted to chat with you about this before merging -- not sure if it's the right approach, moving the errors to the messages framework? 

(still an issue: the error message loads, but when the page reloads, it's back to the social login screen) 
<img width="1063" alt="Screenshot 2023-08-03 at 4 13 49 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/9ba60f93-bb54-4157-a8d4-f3fae8cad9ae">
