### PR TITLE
#570 Show non-field errors on email login form

### DIFF
--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -58,6 +58,15 @@
             <div class="mx-auto space-y-4 w-2/3" id="signup_form">
               {% csrf_token %}
 
+              <!-- Display non-field errors -->
+              {% if form.non_field_errors %}
+                <div class="alert alert-danger">
+                  {% for error in form.non_field_errors %}
+                     {{ error }}
+                  {% endfor %}
+                </div>
+              {% endif %}
+
               {% for field in form.visible_fields %}
                 <div>
                   {% if field.label == "E-mail" or field.label == "Password" %}


### PR DESCRIPTION
Part of #570 

- Displays non-field errors in the email login form 

@gregnewman There is still an issue -- the error shows in the email form, which is hidden when the page reloads when the user's password is wrong. Is this better solved on the JS side of things? 


https://github.com/cppalliance/temp-site/assets/2286304/35e4f375-6288-4ab0-bc01-e54d3c94e9ef

