### PR TITLE
Add boost.org URL and certificate

### DIFF
--- a/kube/boost/templates/configmap-nginx.yaml
+++ b/kube/boost/templates/configmap-nginx.yaml
@@ -12,8 +12,14 @@ data:
     }
 
     server {
+      listen 80;
+      server_name {{.Values.publicFqdn2}};
+      return 301 $scheme://www.{{.Values.publicFqdn2}}$request_uri;
+    }
+
+    server {
       listen 80 deferred default;
-      server_name www.{{.Values.publicFqdn}};
+      server_name www.{{.Values.publicFqdn}} www.{{.Values.publicFqdn2}} ;
 
       error_log /dev/stdout info;
       access_log /dev/stdout main;

--- a/kube/boost/templates/ingress.yaml
+++ b/kube/boost/templates/ingress.yaml
@@ -42,6 +42,26 @@ spec:
                 name: boost
                 port:
                   number: 80
+    - host: www.{{.Values.publicFqdn2 }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: boost
+                port:
+                  number: 80
+    - host: {{ .Values.publicFqdn2 }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: boost
+                port:
+                  number: 80
 
 {{- else if eq .Values.ingressType "gce" }}
 
@@ -62,12 +82,9 @@ metadata:
       {{ .Values.clientMaxBodySize|quote }}
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingressStaticIp }}
 spec:
-  # managed cert. see above.
-  # tls:
-  #   - hosts:
-  #       - www.{{.Values.publicFqdn}}
-  #       - {{ .Values.publicFqdn }}
-  #     secretName: www.{{.Values.publicFqdn}}-tls-staging
+  # also managed cert. see above.
+  tls:
+    - secretName: {{ .Values.secretCertName }}
   rules:
     - host: www.{{.Values.publicFqdn}}
       http:
@@ -80,6 +97,26 @@ spec:
                 port:
                   number: 80
     - host: {{ .Values.publicFqdn }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: boost
+                port:
+                  number: 80
+    - host: www.{{.Values.publicFqdn2 }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: boost
+                port:
+                  number: 80
+    - host: {{ .Values.publicFqdn2 }}
       http:
         paths:
           - path: /

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -22,6 +22,7 @@ initCommands:
     command: ./manage.py collectstatic --noinput
 
 publicFqdn: &fqdn cppal-dev.boost.cppalliance.org
+publicFqdn2: &fqdn2 boost.org
 
 Env:
   - name: DJANGO_SETTINGS_MODULE
@@ -54,9 +55,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "cppal-dev.boost.cppalliance.org, www.cppal-dev.boost.cppalliance.org"
+    value: "cppal-dev.boost.cppalliance.org, www.cppal-dev.boost.cppalliance.org, boost.org, www.boost.org"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://0.0.0.0, http://localhost, https://cppal-dev.boost.cppalliance.org, https://www.cppal-dev.boost.cppalliance.org"
+    value: "http://0.0.0.0, http://localhost, https://cppal-dev.boost.cppalliance.org, https://www.cppal-dev.boost.cppalliance.org, https://boost.org, https://www.boost.org"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS
@@ -169,6 +170,7 @@ NginxVolumeMounts:
 
 ingressType: gce
 managedCertName: managed-cert-cppal-dev
+secretCertName: boostorgcert
 ingressStaticIp: cppal-dev-ingress1
 redisInstall: true
 celeryInstall: true

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -22,6 +22,7 @@ initCommands:
     command: ./manage.py collectstatic --noinput
 
 publicFqdn: &fqdn boost.cppalliance.org
+publicFqdn2: &fqdn2 boost.org
 
 Env:
   - name: DJANGO_SETTINGS_MODULE
@@ -54,9 +55,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "boost.cppalliance.org, www.boost.cppalliance.org"
+    value: "boost.cppalliance.org, www.boost.cppalliance.org, boost.org, www.boost.org"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://0.0.0.0, http://localhost, https://boost.cppalliance.org, https://www.boost.cppalliance.org"
+    value: "http://0.0.0.0, http://localhost, https://boost.cppalliance.org, https://www.boost.cppalliance.org, https://boost.org, https://www.boost.org"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS
@@ -169,6 +170,7 @@ NginxVolumeMounts:
 
 ingressType: gce
 managedCertName: managed-cert-boost-production
+secretCertName: boostorgcert
 ingressStaticIp: boost-production-ingress1
 redisInstall: true
 celeryInstall: true

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -22,6 +22,7 @@ initCommands:
     command: ./manage.py collectstatic --noinput
 
 publicFqdn: &fqdn stage.boost.cppalliance.org
+publicFqdn2: &fqdn2 stage.boost.org
 
 Env:
   - name: DJANGO_SETTINGS_MODULE
@@ -54,9 +55,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "stage.boost.cppalliance.org, www.stage.boost.cppalliance.org"
+    value: "stage.boost.cppalliance.org, www.stage.boost.cppalliance.org, stage.boost.org, www.stage.boost.org"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://0.0.0.0, http://localhost, https://stage.boost.cppalliance.org, https://www.stage.boost.cppalliance.org"
+    value: "http://0.0.0.0, http://localhost, https://stage.boost.cppalliance.org, https://www.stage.boost.cppalliance.org, https://stage.boost.org, https://www.stage.boost.org"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS
@@ -169,6 +170,7 @@ NginxVolumeMounts:
 
 ingressType: gce
 managedCertName: managed-cert-boost-stage
+secretCertName: boostorgcert
 ingressStaticIp: boost-stage-ingress1
 redisInstall: true
 celeryInstall: true

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -22,6 +22,7 @@ initCommands:
     command: ./manage.py collectstatic --noinput
 
 publicFqdn: &fqdn boost.revsys.dev
+publicFqdn2: &fqdn2 boost.org
 
 Env:
   - name: DJANGO_SETTINGS_MODULE
@@ -54,9 +55,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "boost.revsys.dev, www.boost.revsys.dev"
+    value: "boost.revsys.dev, www.boost.revsys.dev, boost.org, www.boost.org"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://0.0.0.0, http://localhost, https://boost.revsys.dev, https://www.boost.revsys.dev"
+    value: "http://0.0.0.0, http://localhost, https://boost.revsys.dev, https://www.boost.revsys.dev, https://boost.org, https://www.boost.org"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS


### PR DESCRIPTION
The website should be able to serve content from the name "boost.org", as well as the current development URL.  

Factors to support other domain names:  

- Django recognizes the domain  
- Kubernetes ingress
- SSL certificates  

If the certificate hasn't been updated, that might show an error in the browser, but the page will still load.  
