### PR TITLE
Brandmark link uses relative path

### DIFF
--- a/templates/includes/_header.html
+++ b/templates/includes/_header.html
@@ -10,11 +10,11 @@
         <div class="w-[100px]">
           <a href="{% url 'home' %}">
               <img class="hidden w-auto dark:inline-block h-[25px] -mb-[1px]"
-                   src="{{ request.scheme }}://{{ request.get_host }}{% static 'img/Boost_Brandmark_WhiteBoost_Transparent.svg' %}"
+                   src="{% static 'img/Boost_Brandmark_WhiteBoost_Transparent.svg' %}"
                    alt="Boost">
 
               <img class="inline-block w-auto dark:hidden h-[25px] -mb-[1px]"
-                   src="{{ request.scheme }}://{{ request.get_host }}{% static 'img/Boost_Brandmark_BlackBoost_Transparent.svg' %}"
+                   src="{% static 'img/Boost_Brandmark_BlackBoost_Transparent.svg' %}"
                    alt="Boost">
           </a>
         </div>


### PR DESCRIPTION
Have the `Boost_Brandmark_BlackBoost_Transparent.svg` image use a relative path instead of absolute. 

The issue with an absolute path containing "request.scheme" is that Django thinks the request scheme is http when it's really behind a load balancer in production, serving the page with https.  In Firefox, an https page with http images generates a browser error.

