### PR TITLE
Reduce max database connections

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -159,7 +159,7 @@ except (ImproperlyConfigured, environs.EnvError):
             "PORT": env.int("PGPORT", default=5432),
             "USER": env("PGUSER"),
             "CONN_MAX_AGE": 0,
-            "OPTIONS": {"MAX_CONNS": 100},
+            "OPTIONS": {"MAX_CONNS": env("MAX_CONNECTIONS", default=20)},
         }
     }
 


### PR DESCRIPTION
Added `MAX_CONNECTIONS` environment variable and set it to default to 20 as a reasonable default.

Fixes #590