### PR TITLE
#512 Add last 2 published entries to the homepage context

### DIFF
--- a/ak/tests/test_default_pages.py
+++ b/ak/tests/test_default_pages.py
@@ -11,8 +11,26 @@ def test_homepage(db, tp):
     if not url:
         url = "/"
 
-    response = tp.get(url)
-    tp.response_200(response)
+    response = tp.get_check_200(url)
+    # Check that "entries" is in the context
+    assert "entries" in response.context
+
+
+def test_homepage_beta(db, tp):
+    """Ensure we can hit the beta homepage"""
+    url = tp.reverse("home-beta")
+
+    tp.get_check_200(url)
+
+
+def test_homepage_beta_context(db, tp):
+    """Ensure have the expected context data on the homepage"""
+    # Use any page that is named 'home' otherwise use /
+    url = tp.reverse("home-beta")
+    response = tp.get_check_200(url)
+
+    # Check that "entries" is in the context
+    assert "entries" in response.context
 
 
 def test_200_page(db, tp):

--- a/ak/views.py
+++ b/ak/views.py
@@ -7,6 +7,7 @@ from django.views.generic import TemplateView
 
 from config.settings import JDOODLE_API_CLIENT_ID, JDOODLE_API_CLIENT_SECRET
 from libraries.models import Category, Library
+from news.models import Entry
 from versions.models import Version
 
 
@@ -17,6 +18,11 @@ class HomepageView(TemplateView):
     """
 
     template_name = "homepage.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["entries"] = Entry.objects.published().order_by("-publish_at")[:3]
+        return context
 
 
 class HomepageBetaView(TemplateView):
@@ -68,9 +74,12 @@ class HomepageBetaView(TemplateView):
                 context["category"] = categories.filter(
                     slug=self.request.GET["category"]
                 ).first()
+
         context["versions"] = Version.objects.active().order_by("-release_date")
         context["libraries"] = libraries
         context["categories"] = categories
+
+        context["entries"] = Entry.objects.published().order_by("-publish_at")[:2]
         return context
 
     def post(self, request, *args, **kwargs):

--- a/news/models.py
+++ b/news/models.py
@@ -38,6 +38,9 @@ class EntryManager(models.Manager):
             )
         return result
 
+    def published(self):
+        return self.get_queryset().filter(published=True)
+
 
 class Entry(models.Model):
     """A news entry.

--- a/news/tests/test_models.py
+++ b/news/tests/test_models.py
@@ -281,6 +281,17 @@ def test_entry_manager_custom_queryset_tags_mixed(make_entry):
     assert [e.tag for e in entries] == ["", "blogpost", "link", "news", "poll", "video"]
 
 
+def test_entry_manager_published(make_entry):
+    entry_published = make_entry(Entry, approved=True, published=True)
+    # Check that unpublished, approved entries are not returned
+    make_entry(Entry, approved=True, published=False)
+    # Check that unapproved entries are not returned
+    make_entry(Entry, approved=False)
+    # Check that unpublished entries are not returned
+    make_entry(Entry, approved=False, published=False)
+    assert list(Entry.objects.published()) == [entry_published]
+
+
 def test_blogpost():
     blogpost = baker.make("BlogPost")
     assert isinstance(blogpost, Entry)

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -108,55 +108,49 @@
     </div>
 
     <!-- RECENT NEWS & JOIN CONVERSATION -->
-    <div class="my-4 md:flex md:my-16 md:space-x-4">
-      <div class="py-5 px-4 bg-white rounded md:px-11 md:w-1/2 dark:bg-charcoal">
-        <div class="flex justify-between items-center mb-6">
-          <span class="inline py-1 px-3 w-auto text-sm uppercase rounded md:text-base text-green bg-green/10">recent news</span>
-          <span class="inline w-auto text-xs uppercase md:text-base text-orange"><a href="{% url 'news' %}">See All ></a></span>
-        </div>
-        <div class="space-y-8 divide-y divide-gray-200 dark:divide-slate">
-          <div class="pt-6">
-            <h3 class="mb-2 text-xl">Name of Article</h3>
-            <p class="mb-3">Category | 4/5/22</p>
-            <p class="mb-3">Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum... <a href="" class="text-orange">Read&nbsp;More</a></p>
+    {% if entries %}
+      <div class="my-4 md:flex md:my-16 md:space-x-4">
+        <div class="py-5 px-4 bg-white rounded md:px-11 md:w-1/2 dark:bg-charcoal">
+          <div class="flex justify-between items-center mb-6">
+            <span class="inline py-1 px-3 w-auto text-sm uppercase rounded md:text-base text-green bg-green/10">recent news</span>
+            <span class="inline w-auto text-xs uppercase md:text-base text-orange"><a href="{% url 'news' %}">See All ></a></span>
           </div>
-          <div class="pt-6">
-            <h3 class="mb-2 text-xl">Name of Article</h3>
-            <p class="mb-3">Category | 4/5/22</p>
-            <p class="mb-3">Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum... <a href="" class="text-orange">Read&nbsp;More</a></p>
-          </div>
-          <div class="pt-6">
-            <h3 class="mb-2 text-xl">Name of Article</h3>
-            <p class="mb-3">Category | 4/5/22</p>
-            <p class="mb-3">Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum... <a href="" class="text-orange">Read&nbsp;More</a></p>
+          <div class="space-y-8 divide-y divide-gray-200 dark:divide-slate">
+            {% for entry in entries %}
+              <div class="pt-6">
+                <h3 class="mb-2 text-xl">{{ entry.title }}</h3>
+                <p class="mb-3">{{ entry.publish_at|date:"m/d/Y" }}</p>
+                <p class="mb-3">{{ entry.content|truncatewords:20 }}... <a href="{% url 'news-detail' slug=entry.slug %}" class="text-orange">Read&nbsp;More</a></p>
+              </div>
+            {% endfor %}
           </div>
         </div>
-      </div>
-      <div class="py-5 px-4 my-4 bg-white rounded md:px-11 md:my-0 md:w-1/2 dark:bg-charcoal">
-        <div class="flex justify-between items-center mb-6">
-          <span class="inline py-1 px-3 w-auto text-sm uppercase rounded md:text-base text-green bg-green/10">Join the conversation</span>
-          <span class="inline w-auto text-xs uppercase md:text-base text-orange"></span>
-        </div>
-        <div class="space-y-8 divide-y divide-gray-200 dark:divide-slate">
-          <div class="pt-6">
-            <h3 class="text-xl">Topic of discussion headline from the Forum</h3>
-            <div class="mt-3"><img src="{% static 'img/fpo/user.png' %}" alt="user" class="inline mr-3" /> Name of Author</div>
+        <div class="py-5 px-4 my-4 bg-white rounded md:px-11 md:my-0 md:w-1/2 dark:bg-charcoal">
+          <div class="flex justify-between items-center mb-6">
+            <span class="inline py-1 px-3 w-auto text-sm uppercase rounded md:text-base text-green bg-green/10">Join the conversation</span>
+            <span class="inline w-auto text-xs uppercase md:text-base text-orange"></span>
           </div>
-          <div class="pt-6">
-            <h3 class="text-xl">Topic of discussion headline from the Forum</h3>
-            <div class="mt-3"><img src="{% static 'img/fpo/user.png' %}" alt="user" class="inline mr-3" /> Name of Author</div>
-          </div>
-          <div class="pt-6">
-            <h3 class="text-xl">Topic of discussion headline from the Forum</h3>
-            <div class="mt-3"><img src="{% static 'img/fpo/user.png' %}" alt="user" class="inline mr-3" /> Name of Author</div>
-          </div>
-          <div class="pt-6">
-            <h3 class="text-xl">Topic of discussion headline from the Forum</h3>
-            <div class="mt-3"><img src="{% static 'img/fpo/user.png' %}" alt="user" class="inline mr-3" /> Name of Author</div>
+          <div class="space-y-8 divide-y divide-gray-200 dark:divide-slate">
+            <div class="pt-6">
+              <h3 class="text-xl">Topic of discussion headline from the Forum</h3>
+              <div class="mt-3"><img src="{% static 'img/fpo/user.png' %}" alt="user" class="inline mr-3" /> Name of Author</div>
+            </div>
+            <div class="pt-6">
+              <h3 class="text-xl">Topic of discussion headline from the Forum</h3>
+              <div class="mt-3"><img src="{% static 'img/fpo/user.png' %}" alt="user" class="inline mr-3" /> Name of Author</div>
+            </div>
+            <div class="pt-6">
+              <h3 class="text-xl">Topic of discussion headline from the Forum</h3>
+              <div class="mt-3"><img src="{% static 'img/fpo/user.png' %}" alt="user" class="inline mr-3" /> Name of Author</div>
+            </div>
+            <div class="pt-6">
+              <h3 class="text-xl">Topic of discussion headline from the Forum</h3>
+              <div class="mt-3"><img src="{% static 'img/fpo/user.png' %}" alt="user" class="inline mr-3" /> Name of Author</div>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <!-- END RECENT NEWS & JOIN CONVERSATION -->
 
     <!-- BOOST LIBRARIES LOGOS AND TESTIMONIALS -->

--- a/templates/homepage_beta.html
+++ b/templates/homepage_beta.html
@@ -191,34 +191,20 @@
           </div>
         </div>
         <div class="grid grid-cols-1 grid-rows-2 gap-y-10 md:grid-cols-2 md:grid-rows-1 md:gap-x-10 lg:gap-y-0">
-          <div class="flex flex-col col-span-1 p-5 pt-0 h-full border-gray-200 md:mb-10 dark:border-slate">
-            <div class="">
-              <h3 class="pb-2 mb-2 text-2xl capitalize border-b border-gray-400 text-orange dark:border-slate">Article Name</h3>
-              <p class="mb-3">Category | 4/5/22</p>
-              <p class="overflow-x-auto mb-3">
-                Boost.MySQL is an Asio-based network client which lets you access MySQL
-                and MariaDB databases using your own data types New in Boost 1.82.0,
-                check it out here https://https://boost.org/libs/mysql Get Boost:
-                https://boost.org/users/history/version_1_82_0.html #boost #cpp
-                #cplusplus #mysql #mariadb #database... <a href="" class="text-sky-600">Read&nbsp;More</a>
-              </p>
-              <img src="{% static 'img/fpo/news-1.png' %}" class="news-image" />
-            </div>
-          </div>
-          <div class="flex flex-col col-span-1 p-5 pt-0 h-full md:mb-10">
-            <div class="">
-              <h3 class="pb-2 mb-2 text-2xl capitalize border-b border-gray-400 text-orange dark:border-slate">Article Name</h3>
-              <p class="mb-3">Category | 4/5/22</p>
-              <p class="overflow-x-auto mb-3">
-                Boost 1.82.0 is released for the Spring season! Release Notes:
-                https://boost.org/users/history/version_1_82_0.html Downloads:
-                http://boost.org/users/news/version_1.82.0 Direct Download:
-                https://boostorg.jfrog.io/artifactory/main/release/1.82.0 #boost #cpp
-                #cplusplus <a href="" class="text-sky-600">Read&nbsp;More</a>
-              </p>
-              <img src="{% static 'img/fpo/news-2.png' %}" class="news-image" />
-            </div>
-          </div>
+          {% if entries %}
+            {% for entry in entries %}
+              <div class="flex flex-col col-span-1 p-5 pt-0 h-full border-gray-200 md:mb-10 dark:border-slate">
+                <div class="">
+                  <h3 class="pb-2 mb-2 text-2xl capitalize border-b border-gray-400 text-orange dark:border-slate">{{ entry.title }}</h3>
+                  <p class="mb-3">{{ entry.publish_at|date:"m/d/Y" }}</p>
+                  <p class="overflow-x-auto mb-3">
+                    {{ entry.content|truncatewords:20 }}... <a href="{% url 'news-detail' slug=entry.slug %}" class="text-sky-600">Read&nbsp;More</a>
+                  </p>
+                  <img src="{{ entry.image.url }}" class="news-image" />
+                </div>
+              </div>
+            {% endfor %}
+          {% endif %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #519 

- Add a `published()` method on the Entry manager 
- Return the most recent 3 news articles on the main homepage and most recent 2 on the beta homepage, as I wasn't sure which one we were using 
- Updated both homepage templates 
- Updated tests 
