### PR TITLE
Auth pages styling

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -40,7 +40,7 @@
     @apply w-full rounded bg-white dark:bg-charcoal border border-slate;
   }
   input[type=email] {
-    @apply w-full rounded bg-white dark:bg-charcoal border border-slate mt-3;
+    @apply w-full rounded bg-white dark:bg-charcoal border border-slate;
   }
   input[type=checkbox] {
     @apply mr-3 rounded bg-white dark:bg-charcoal border border-slate text-orange;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -665,7 +665,6 @@ textarea {
 }
 
 input[type=email] {
-  margin-top: 0.75rem;
   width: 100%;
   border-radius: 0.25rem;
   border-width: 1px;
@@ -1784,6 +1783,12 @@ select.dropdown {
   margin-bottom: calc(2rem * var(--tw-space-y-reverse));
 }
 
+.space-y-11 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2.75rem * var(--tw-space-y-reverse));
+}
+
 .space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-x-reverse: 0;
   margin-right: calc(1rem * var(--tw-space-x-reverse));
@@ -1812,12 +1817,6 @@ select.dropdown {
   --tw-space-x-reverse: 0;
   margin-right: calc(2rem * var(--tw-space-x-reverse));
   margin-left: calc(2rem * calc(1 - var(--tw-space-x-reverse)));
-}
-
-.space-y-11 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-y-reverse: 0;
-  margin-top: calc(2.75rem * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(2.75rem * var(--tw-space-y-reverse));
 }
 
 .space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -2530,6 +2529,16 @@ select.dropdown {
   color: rgb(229 231 235 / var(--tw-text-opacity));
 }
 
+.\!text-white {
+  --tw-text-opacity: 1 !important;
+  color: rgb(255 255 255 / var(--tw-text-opacity)) !important;
+}
+
+.text-red-600 {
+  --tw-text-opacity: 1;
+  color: rgb(220 38 38 / var(--tw-text-opacity));
+}
+
 .underline {
   text-decoration-line: underline;
 }
@@ -2662,6 +2671,27 @@ select.dropdown {
   background-color: rgb(255 255 255 / 0.6);
 }
 
+.hover\:bg-orange\/90:hover {
+  background-color: rgb(255 159 0 / 0.9);
+}
+
+.hover\:bg-orange\/60:hover {
+  background-color: rgb(255 159 0 / 0.6);
+}
+
+.hover\:bg-orange\/70:hover {
+  background-color: rgb(255 159 0 / 0.7);
+}
+
+.hover\:bg-charcoal:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(23 42 52 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-orange\/80:hover {
+  background-color: rgb(255 159 0 / 0.8);
+}
+
 .hover\:text-orange:hover {
   --tw-text-opacity: 1;
   color: rgb(255 159 0 / var(--tw-text-opacity));
@@ -2672,6 +2702,11 @@ select.dropdown {
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
+.hover\:\!text-white:hover {
+  --tw-text-opacity: 1 !important;
+  color: rgb(255 255 255 / var(--tw-text-opacity)) !important;
+}
+
 .hover\:shadow-\[0_0_5px_5px_rgba\(0\2c 0\2c 0\2c 0\.05\)\]:hover {
   --tw-shadow: 0 0 5px 5px rgba(0,0,0,0.05);
   --tw-shadow-colored: 0 0 5px 5px var(--tw-shadow-color);
@@ -2680,6 +2715,11 @@ select.dropdown {
 
 .hover\:drop-shadow-\[0_15px_15px_rgba\(0\2c 100\2c 100\2c 0\.05\)\]:hover {
   --tw-drop-shadow: drop-shadow(0 15px 15px rgba(0,100,100,0.05));
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.hover\:drop-shadow-md:hover {
+  --tw-drop-shadow: drop-shadow(0 4px 3px rgb(0 0 0 / 0.07)) drop-shadow(0 2px 2px rgb(0 0 0 / 0.06));
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
@@ -2840,6 +2880,11 @@ select.dropdown {
 .dark .dark\:hover\:bg-slate:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(49 74 87 / var(--tw-bg-opacity));
+}
+
+.dark .dark\:hover\:bg-charcoal:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(23 42 52 / var(--tw-bg-opacity));
 }
 
 .dark .dark\:hover\:text-orange:hover {

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -11,86 +11,76 @@
 {% block content %}
 
   <div class="py-0 px-3 mb-3 md:py-6 md:px-0">
-    <div class="md:pt-11 md:mt-11 w-full md:w-1/2 mx-auto" x-data="{ tab: '#social' }">
+
+    <div class="md:pt-11 md:mt-11 w-full bg-white dark:bg-charcoal mx-auto rounded py-6 px-3">
       <div class="md:w-full">
         <h1 class="text-4xl text-center">{% trans "Log In" %}</h1>
+        <p class="mt-0 text-center">{% blocktrans %}If you have not created an account yet, please
+            <a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}
+        </p>
       </div>
 
-      <div class="space-y-4 w-full text-center">
-        {% get_providers as socialaccount_providers %}
+      <div class="w-full">
 
-        {% if socialaccount_providers %}
-          <p class="mt-0 text-center">
-            {% blocktrans with site.name as site_name %}
-              <a :class="tab === '#social' ? 'text-slate dark:text-white' : 'text-orange'"
-                 href="#"
-                 data-toggle="tab"
-                 x-on:click.prevent="tab='#social'"
-              >
-                Log in with one of your existing third party accounts<br/>
-              </a> or you can
-              <a :class="tab === '#email' ? 'text-slate dark:text-white' : 'text-orange'"
-                 href="#"
-                 data-toggle="tab"
-                 x-on:click.prevent="tab='#email'"
-              >
-                use your email
-              </a>
-            {% endblocktrans %}
-          </p>
+        <div class="w-full md:flex md:divide-x divide-gray-200 space-y-11 md:space-y-0">
+          <div class="socialaccount_ballot w-full md:w-1/2">
+            {% get_providers as socialaccount_providers %}
 
-          <div class="socialaccount_ballot" x-show="tab == '#social'" x-cloak>
+            {% if socialaccount_providers %}
+              {% blocktrans with site.name as site_name %}
+                <h2 class="text-xl text-center mb-11">Log in with one of your existing third party accounts</h2>
+              {% endblocktrans %}
 
-            <div class="space-y-4 w-full">
-              {% include "socialaccount/snippets/provider_list.html" with process="login" %}
-            </div>
-            {% include "socialaccount/snippets/login_extra.html" %}
+              <div class="socialaccount_ballot">
 
+                <div class="space-y-6 w-full text-center">
+                  {% include "socialaccount/snippets/provider_list.html" with process="login" %}
+                </div>
+                {% include "socialaccount/snippets/login_extra.html" %}
+
+              </div>
+
+            {% endif %}
           </div>
 
-        {% else %}
-          <p class="mt-0 text-center">{% blocktrans %}If you have not created an account yet, then please
-            <a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</p>
-        {% endif %}
+          <div class="w-full md:w-1/2">
+            <h2 class="text-xl text-center">Or Log In with Email</h2>
+            <form class="login" method="POST" action="{% url 'account_login' %}">
+              <div class="mx-auto space-y-4 w-2/3" id="signup_form">
+                {% csrf_token %}
 
-        <div x-show="tab == '#email'" x-cloak>
-          <form class="login" method="POST" action="{% url 'account_login' %}">
-            <div class="mx-auto space-y-4 w-2/3" id="signup_form">
-              {% csrf_token %}
-
-              <!-- Display non-field errors -->
-              {% if form.non_field_errors %}
-                <div class="alert alert-danger">
+                <!-- Display non-field errors -->
+                {% if form.non_field_errors %}
                   {% for error in form.non_field_errors %}
+                    <div class="py-1 px-3 text-white bg-red-600">
                      {{ error }}
+                    </div>
                   {% endfor %}
+                {% endif %}
+
+                {% for field in form.visible_fields %}
+                  <div>
+                    <label class="text-xs uppercase text-slate dark:text-white/70">{{ field.label }}
+                    {{ field }}
+                    </label>
+                    {% if field.help_text %}
+                      <small>{{ field.help_text }}</small>
+                    {% endif %}
+                  </div>
+                {% endfor %}
+
+                {% if redirect_field_value %}
+                  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
+                {% endif %}
+
+                <div class="flex justify-between mb-4">
+                  <a class="text-orange" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+                  <button type="submit"
+                          class="py-3 px-8 text-sm text-base font-medium text-white uppercase rounded-md border md:py-1 md:px-4 md:text-lg bg-orange hover:bg-orange/80 border-orange dark:bg-slate dark:hover:bg-charcoal dark:text-white hover:drop-shadow-md">{% trans "Login" %}</button>
                 </div>
-              {% endif %}
-
-              {% for field in form.visible_fields %}
-                <div>
-                  {% if field.label == "E-mail" or field.label == "Password" %}
-                  {% else %}
-                    <label class="text-xs uppercase text-slate dark:text-white/70">{{ field.label }}</label>
-                  {% endif %}
-                  {{ field }}
-                  {% if field.help_text %}
-                    <small>{{ field.help_text }}</small>
-                  {% endif %}
-                </div>
-              {% endfor %}
-
-              {% if redirect_field_value %}
-                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
-              {% endif %}
-
-              <div class="flex justify-between mb-4">
-                <a class="text-orange" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
-                <button type="submit"
-                        class="py-3 px-8 text-sm text-base font-medium text-white uppercase rounded-md border md:py-1 md:px-4 md:text-lg bg-orange border-orange dark:bg-charcoal dark:text-orange">{% trans "Login" %}</button>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
       </div>
     </div>

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -6,27 +6,33 @@
 {% block head_title %}{% trans "Password Reset" %}{% endblock %}
 
 {% block content %}
-<div class="my-6 text-center">
-  <div class="py-6">
-    <h1 class="text-4xl">{% trans "Password Reset" %}</h1>
-    {% if user.is_authenticated %}
-    {% include "account/snippets/already_logged_in.html" %}
-    {% endif %}
 
-    <p>{% trans "Forgotten your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}</p>
+  <div class="py-0 px-3 mb-3 md:py-6 md:px-0">
+    <div class="md:pt-11 md:mt-11 w-full bg-white dark:bg-charcoal mx-auto rounded py-6 px-3">
+      <div class="md:w-full text-center">
+        <h1 class="text-4xl">{% trans "Password Reset" %}</h1>
+        {% if user.is_authenticated %}
+        {% include "account/snippets/already_logged_in.html" %}
+        {% endif %}
 
-    <form method="POST" action="{% url 'account_reset_password' %}" class="password_reset">
-        {% csrf_token %}
-        <div class="mx-auto w-full md:w-1/2">
-          {{ form.as_p }}
-          <input type="submit"
-                 value="{% trans 'Reset My Password' %}"
-                 class="py-3 px-4 uppercase rounded border border-orange text-orange"
-          />
-        </div>
-    </form>
+        <p>{% trans "Forgot your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}</p>
 
-    <p class="mt-6">{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
+        <form method="POST" action="{% url 'account_reset_password' %}" class="password_reset text-left">
+            {% csrf_token %}
+            <div class="mx-auto w-full md:w-1/2">
+              {{ form.as_p }}
+
+              <div class="my-3 text-center">
+                <button type="submit"
+                        class="py-3 px-8 text-sm text-base font-medium text-white uppercase rounded-md border md:py-1 md:px-4 md:text-lg bg-orange hover:bg-orange/80 border-orange dark:bg-slate dark:hover:bg-charcoal dark:text-white hover:drop-shadow-md">
+                  {% trans 'Reset My Password' %}
+                </button>
+              </div>
+            </div>
+        </form>
+
+        <p class="mt-6">{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
+      </div>
+    </div>
   </div>
-</div>
 {% endblock %}

--- a/templates/account/password_reset_done.html
+++ b/templates/account/password_reset_done.html
@@ -6,11 +6,17 @@
 {% block head_title %}{% trans "Password Reset" %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "Password Reset" %}</h1>
+  <div class="py-0 px-3 mb-3 md:py-6 md:px-0">
+    <div class="md:pt-11 md:mt-11 w-full bg-white dark:bg-charcoal mx-auto rounded py-6 px-3">
+      <div class="md:w-full text-center">
+        <h1 class="text-4xl">{% trans "Password Reset" %}</h1>
 
-    {% if user.is_authenticated %}
-    {% include "account/snippets/already_logged_in.html" %}
-    {% endif %}
+        {% if user.is_authenticated %}
+        {% include "account/snippets/already_logged_in.html" %}
+        {% endif %}
 
-    <p>{% blocktrans %}We have sent you an e-mail. If you have not received it please check your spam folder. Otherwise contact us if you do not receive it in a few minutes.{% endblocktrans %}</p>
+        <p>{% blocktrans %}We have sent you an e-mail. If you have not received it please check your spam folder. Otherwise contact us if you do not receive it in a few minutes.{% endblocktrans %}</p>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/templates/account/password_reset_from_key.html
+++ b/templates/account/password_reset_from_key.html
@@ -4,16 +4,54 @@
 {% block head_title %}{% trans "Change Password" %}{% endblock %}
 
 {% block content %}
-    <h1>{% if token_fail %}{% trans "Bad Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
+  <div class="py-0 px-3 mb-3 md:py-6 md:px-0">
+    <div class="md:pt-11 md:mt-11 w-full bg-white dark:bg-charcoal mx-auto rounded py-6 px-3">
+      <div class="md:w-full text-center">
+        <h1 class="text-4xl">{% if token_fail %}{% trans "Bad Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
 
-    {% if token_fail %}
-        {% url 'account_reset_password' as passwd_reset_url %}
-        <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
-    {% else %}
-        <form method="POST" action="{{ action_url }}">
-            {% csrf_token %}
-            {{ form.as_p }}
-            <input type="submit" name="action" value="{% trans 'change password' %}"/>
-        </form>
-    {% endif %}
+        {% if token_fail %}
+            {% url 'account_reset_password' as passwd_reset_url %}
+            <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
+        {% else %}
+            <form method="POST" action="{{ action_url }}">
+              {% csrf_token %}
+
+              <div class="mx-auto space-y-4 w-2/3" id="signup_form">
+                <!-- Display non-field errors -->
+                {% if form.non_field_errors %}
+                  {% for error in form.non_field_errors %}
+                    <div class="py-1 px-3 text-white bg-red-600">
+                     {{ error }}
+                    </div>
+                  {% endfor %}
+                {% endif %}
+
+                {% for field in form.visible_fields %}
+                  {% if field.errors %}
+                    {% for error in field.errors %}
+                      <div class="text-red-600">{{ error }}</div>
+                    {% endfor %}
+                  {% endif %}
+                  <div class="text-left">
+                    <label class="text-xs uppercase text-slate dark:text-white/70">{{ field.label }}
+                      {{ field }}
+                    </label>
+                    {% if field.help_text %}
+                      <small>{{ field.help_text }}</small>
+                    {% endif %}
+                  </div>
+                {% endfor %}
+
+                <div class="my-3 text-center">
+                  <button type="submit"
+                          class="py-3 px-8 text-sm text-base font-medium text-white uppercase rounded-md border md:py-1 md:px-4 md:text-lg bg-orange hover:bg-orange/80 border-orange dark:bg-slate dark:hover:bg-charcoal dark:text-white hover:drop-shadow-md">
+                    {% trans 'change password' %}
+                  </button>
+                </div>
+              </div>
+            </form>
+        {% endif %}
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/templates/account/password_reset_from_key_done.html
+++ b/templates/account/password_reset_from_key_done.html
@@ -4,7 +4,13 @@
 {% block head_title %}{% trans "Change Password" %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "Change Password" %}</h1>
-    {% url 'account_login' as login_url %}
-    <p>{% blocktrans %}Your password is now changed. <a href="{{ login_url }}">Log in</a> with your new password.{% endblocktrans %}</p>
+  <div class="py-0 px-3 mb-3 md:py-6 md:px-0">
+    <div class="md:pt-11 md:mt-11 w-full bg-white dark:bg-charcoal mx-auto rounded py-6 px-3">
+      <div class="md:w-full text-center">
+        <h1 class="text-4xl">{% trans "Change Password" %}</h1>
+        {% url 'account_login' as login_url %}
+        <p>{% blocktrans %}Your password is now changed. <a href="{{ login_url }}">Log in</a> with your new password.{% endblocktrans %}</p>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -20,12 +20,12 @@
         </p>
       </div>
 
-      <div class="w-full text-center">
+      <div class="w-full">
 
         <div class="w-full md:flex md:divide-x divide-gray-200 space-y-11 md:space-y-0">
           <div class="socialaccount_ballot w-full md:w-1/2">
-            <h2 class="text-xl">Sign Up with an existing third party account</h2>
-            <div class="space-y-4 w-full">
+            <h2 class="text-xl text-center mb-11">Sign Up with an existing third party account</h2>
+            <div class="space-y-6 w-full text-center">
               {% providers_media_js %}
               {% include "socialaccount/snippets/provider_list.html" with process="login" %}
               {% include "socialaccount/snippets/login_extra.html" %}
@@ -33,22 +33,30 @@
           </div>
 
           <div class="w-full md:w-1/2">
-            <h2 class="text-xl">Sign Up with Email</h2>
+            <h2 class="text-xl text-center">Or Sign Up with Email</h2>
             <form id="signup_form" method="post" action="{% url 'account_signup' %}">
               <div class="mx-auto space-y-4 w-2/3">
                 {% csrf_token %}
 
-                {% if form.errors %}
-                  {% for error in field.errors %}
-                    <p class="font-bold text-orange">
-                      {{ error|escape }}
-                    </p>
+                <!-- Display non-field errors -->
+                {% if form.non_field_errors %}
+                  {% for error in form.non_field_errors %}
+                    <div class="py-1 px-3 text-white bg-red-600">
+                     {{ error }}
+                    </div>
                   {% endfor %}
                 {% endif %}
 
                 {% for field in form.visible_fields %}
+                  {% if field.errors %}
+                    {% for error in field.errors %}
+                      <div class="text-red-600">{{ error }}</div>
+                    {% endfor %}
+                  {% endif %}
                   <div>
-                    {{ field }}
+                    <label class="text-xs uppercase text-slate dark:text-white/70">{{ field.label }}
+                      {{ field }}
+                    </label>
                     {% if field.help_text %}
                       <small>{{ field.help_text }}</small>
                     {% endif %}
@@ -59,9 +67,9 @@
                   <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
                 {% endif %}
               </div>
-              <div class="my-3">
+              <div class="my-3 text-center">
                 <button type="submit"
-                        class="py-3 px-8 text-sm text-base font-medium text-white uppercase rounded-md border md:py-1 md:px-4 md:text-lg bg-orange border-orange dark:bg-charcoal dark:text-orange"
+                        class="py-3 px-8 text-sm text-base font-medium text-white uppercase rounded-md border md:py-1 md:px-4 md:text-lg bg-orange hover:bg-orange/80 border-orange dark:bg-slate dark:hover:bg-charcoal dark:text-white hover:drop-shadow-md"
                 >
                   {% trans "Sign Up" %}
                 </button>

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -12,7 +12,7 @@
 
   <div class="py-0 px-3 mb-3 md:py-6 md:px-0">
 
-    <div class="md:pt-11 md:mt-11 w-full md:w-1/2 mx-auto" x-data="{ tab: '#social' }">
+    <div class="md:pt-11 md:mt-11 w-full bg-white dark:bg-charcoal mx-auto rounded py-6 px-3">
       <div class="md:w-full">
         <h1 class="text-4xl text-center">{% trans "Sign Up" %}</h1>
         <p class="mt-0 text-center">
@@ -20,68 +20,54 @@
         </p>
       </div>
 
-      <div class="space-y-4 w-full text-center">
-        <p class="mt-0 text-center">
-          <a :class="tab === '#social' ? 'text-slate dark:text-white' : 'text-orange'"
-             href="#"
-             data-toggle="tab"
-             x-on:click.prevent="tab='#social'"
-          >
-            Sign Up with one of your existing third party accounts<br/>
-          </a> or you can
-          <a :class="tab === '#email' ? 'text-slate dark:text-white' : 'text-orange'"
-             href="#"
-             data-toggle="tab"
-             x-on:click.prevent="tab='#email'"
-          >
-            use your email
-          </a>
-        </p>
+      <div class="w-full text-center">
 
-        <div class="socialaccount_ballot" x-show="tab == '#social'" x-cloak>
-
-          <div class="space-y-4 w-full">
-            {% providers_media_js %}
-            {% include "socialaccount/snippets/provider_list.html" with process="login" %}
-            {% include "socialaccount/snippets/login_extra.html" %}
+        <div class="w-full md:flex md:divide-x divide-gray-200 space-y-11 md:space-y-0">
+          <div class="socialaccount_ballot w-full md:w-1/2">
+            <h2 class="text-xl">Sign Up with an existing third party account</h2>
+            <div class="space-y-4 w-full">
+              {% providers_media_js %}
+              {% include "socialaccount/snippets/provider_list.html" with process="login" %}
+              {% include "socialaccount/snippets/login_extra.html" %}
+            </div>
           </div>
 
-        </div>
+          <div class="w-full md:w-1/2">
+            <h2 class="text-xl">Sign Up with Email</h2>
+            <form id="signup_form" method="post" action="{% url 'account_signup' %}">
+              <div class="mx-auto space-y-4 w-2/3">
+                {% csrf_token %}
 
-        <div x-show="tab == '#email'" x-cloak>
-          <form id="signup_form" method="post" action="{% url 'account_signup' %}">
-            <div class="mx-auto space-y-4 w-2/3">
-              {% csrf_token %}
+                {% if form.errors %}
+                  {% for error in field.errors %}
+                    <p class="font-bold text-orange">
+                      {{ error|escape }}
+                    </p>
+                  {% endfor %}
+                {% endif %}
 
-              {% if form.errors %}
-                {% for error in field.errors %}
-                  <p class="font-bold text-orange">
-                    {{ error|escape }}
-                  </p>
+                {% for field in form.visible_fields %}
+                  <div>
+                    {{ field }}
+                    {% if field.help_text %}
+                      <small>{{ field.help_text }}</small>
+                    {% endif %}
+                  </div>
                 {% endfor %}
-              {% endif %}
 
-              {% for field in form.visible_fields %}
-                <div>
-                  {{ field }}
-                  {% if field.help_text %}
-                    <small>{{ field.help_text }}</small>
-                  {% endif %}
-                </div>
-              {% endfor %}
-
-              {% if redirect_field_value %}
-                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
-              {% endif %}
-            </div>
-            <div class="my-11">
-              <button type="submit"
-                      class="py-3 px-8 text-sm text-base font-medium text-white uppercase rounded-md border md:py-1 md:px-4 md:text-lg bg-orange border-orange dark:bg-charcoal dark:text-orange"
-              >
-                {% trans "Sign Up" %}
-              </button>
-            </div>
-          </form>
+                {% if redirect_field_value %}
+                  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
+                {% endif %}
+              </div>
+              <div class="my-3">
+                <button type="submit"
+                        class="py-3 px-8 text-sm text-base font-medium text-white uppercase rounded-md border md:py-1 md:px-4 md:text-lg bg-orange border-orange dark:bg-charcoal dark:text-orange"
+                >
+                  {% trans "Sign Up" %}
+                </button>
+              </div>
+            </form>
+          </div>
         </div>
       </div>
     </div>

--- a/templates/socialaccount/login.html
+++ b/templates/socialaccount/login.html
@@ -1,23 +1,25 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block head_title %}{% trans "Sign In" %}{% endblock %}
+{% block head_title %}{% trans "Log In" %}{% endblock %}
 
 {% block content %}
-<div class="my-6 text-center">
-  <div class="py-6">
-    {% if process == "connect" %}
-      <h1 class="text-4xl">{% blocktrans with provider.name as provider %}Connect {{ provider }}{% endblocktrans %}</h1>
-      <p>{% blocktrans with provider.name as provider %}You are about to connect a new third party account from {{ provider }}.{% endblocktrans %}</p>
-    {% else %}
-      <h1 class="text-4xl">{% blocktrans with provider.name as provider %}Sign In Via {{ provider }}{% endblocktrans %}</h1>
-      <p>{% blocktrans with provider.name as provider %}You are about to sign in using a third party account from {{ provider }}.{% endblocktrans %}</p>
-    {% endif %}
-  </div>
+<div class="py-0 px-3 mb-3 md:py-6 md:px-0">
+    <div class="md:pt-11 md:mt-11 w-full bg-white dark:bg-charcoal mx-auto rounded py-6 px-3">
+      <div class="md:w-full text-center">
+        {% if process == "connect" %}
+          <h1 class="text-4xl">{% blocktrans with provider.name as provider %}Connect {{ provider }}{% endblocktrans %}</h1>
+          <p>{% blocktrans with provider.name as provider %}You are about to connect a new third party account from {{ provider }}.{% endblocktrans %}</p>
+        {% else %}
+          <h1 class="text-4xl">{% blocktrans with provider.name as provider %}Log In with {{ provider }}{% endblocktrans %}</h1>
+          <p>{% blocktrans with provider.name as provider %}You are about to log in using a third party account from {{ provider }}.{% endblocktrans %}</p>
+        {% endif %}
 
-  <form method="post">
-    {% csrf_token %}
-    <button type="submit" class="py-3 px-4 text-white uppercase rounded border border-orange bg-orange">{% trans "Continue" %}</button>
-  </form>
+        <form method="post">
+          {% csrf_token %}
+          <button type="submit" class="py-3 px-8 text-sm text-base font-medium text-white uppercase rounded-md border md:py-1 md:px-4 md:text-lg bg-orange hover:bg-orange/80 border-orange dark:bg-slate dark:hover:bg-charcoal dark:text-white hover:drop-shadow-md">{% trans "Continue" %}</button>
+        </form>
+      </div>
+    </div>
 </div>
 {% endblock %}

--- a/templates/socialaccount/signup.html
+++ b/templates/socialaccount/signup.html
@@ -5,56 +5,52 @@
 {% block head_title %}{% trans "Signup" %}{% endblock %}
 
 {% block content %}
-<div class="my-6 text-center">
-  <div class="py-6">
-    <h1 class="text-4xl">{% trans "Sign Up" %}</h1>
+<div class="py-0 px-3 mb-3 md:py-6 md:px-0">
+  <div class="md:pt-11 md:mt-11 w-full bg-white dark:bg-charcoal mx-auto rounded py-6 px-3">
+    <div class="md:w-full text-center">
+      <h1 class="text-4xl">{% trans "Sign Up" %}</h1>
 
-    <p>{% blocktrans with provider_name=account.get_provider.name site_name=site.name %}You are about to use your {{provider_name}} account to login to
+      <p>{% blocktrans with provider_name=account.get_provider.name site_name=site.name %}You are about to use your {{provider_name}} account to login to
 {{site_name}}. As a final step, please complete the following form:{% endblocktrans %}</p>
-  </div>
 
-  <form id="signup_form" method="post" action="{% url 'socialaccount_signup' %}" class="w-full md:w-1/2 mx-auto">
-    {% csrf_token %}
+      <form id="signup_form" method="post" action="{% url 'socialaccount_signup' %}" class="w-full md:w-1/2 mx-auto">
+        {% csrf_token %}
 
-    {% if form.errors %}
-      {% for error in field.errors %}
-        <p class="font-bold text-orange">
-          {{ error|escape }}
-        </p>
-      {% endfor %}
-    {% endif %}
-
-    <!-- Display non-field errors -->
-    {% if form.non_field_errors %}
-      <div class="alert alert-danger">
-        {% for error in form.non_field_errors %}
-          {{ error }}
-        {% endfor %}
-      </div>
-    {% endif %}
-
-    {% for field in form.visible_fields %}
-      {% if field.errors %}
-        {% for error in field.errors %}
-          <div class="error-message">{{ error }}</div>
-          {% if field.name == "email" and "account already exists with this e-mail" in error %}
-            <p><button><a href="{% url 'account_login' %}" class="py-3 px-4 text-white uppercase rounded border border-orange bg-orange">{% trans "Log in" %}</a></button></p>
-          {% endif %}
-        {% endfor %}
-      {% endif %}
-      <div>
-        {{ field }}
-        {% if field.help_text %}
-          <small>{{ field.help_text }}</small>
+        <!-- Display non-field errors -->
+        {% if form.non_field_errors %}
+          {% for error in form.non_field_errors %}
+            <div class="py-1 px-3 text-white bg-red-600">
+             {{ error }}
+            </div>
+          {% endfor %}
         {% endif %}
-      </div>
-    {% endfor %}
 
-    {% if redirect_field_value %}
-    <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-    {% endif %}
-    <button type="submit" class="py-3 px-4 text-white uppercase rounded border border-orange bg-orange">{% trans "Sign Up" %}</button>
-  </form>
+        {% for field in form.visible_fields %}
+          {% if field.errors %}
+            {% for error in field.errors %}
+              <div class="text-red-600">{{ error }}</div>
+            {% endfor %}
+          {% endif %}
+
+          <div class="text-left">
+            <label class="text-xs uppercase text-slate dark:text-white/70">{{ field.label }}
+              {{ field }}
+            </label>
+            {% if field.help_text %}
+              <small>{{ field.help_text }}</small>
+            {% endif %}
+          </div>
+        {% endfor %}
+
+        {% if redirect_field_value %}
+        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+        {% endif %}
+        <div class="my-3 text-center">
+          <button type="submit" class="py-3 px-8 text-sm text-base font-medium text-white uppercase rounded-md border md:py-1 md:px-4 md:text-lg bg-orange hover:bg-orange/80 border-orange dark:bg-slate dark:hover:bg-charcoal dark:text-white hover:drop-shadow-md">{% trans "Sign Up" %}</button>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>
 
 {# keep this here for postcss <span class="errorlist"></span> #}

--- a/templates/socialaccount/snippets/provider_list.html
+++ b/templates/socialaccount/snippets/provider_list.html
@@ -12,7 +12,7 @@
 {% endfor %}
 {% endif %}
     <a title="{{provider.name}}"
-       class="w-2/3 mx-auto block px-8 py-3 text-base font-medium rounded-md border border-orange text-white bg-orange dark:bg-slate md:py-4 md:text-lg md:px-10 {{provider.id}}"
+       class="w-2/3 mx-auto block px-8 py-3 text-base font-medium rounded-md border border-orange !text-white hover:!text-white bg-orange hover:bg-orange/80 dark:bg-slate dark:hover:bg-charcoal hover:drop-shadow-md md:py-4 md:text-lg md:px-10 {{provider.id}}"
        href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}"
     >
       {% if provider.name == "GitHub" %}


### PR DESCRIPTION
Styles all auth pages consistently.  Sign up and Log in are side by side now removing the confusing links to switch between forms.  Form errors are now properly displayed and styles.  All pages related to social auth flow are styled as well as the forgot password flow.