### PR TITLE
Mailman variables

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -263,10 +263,20 @@ CACHES = {
     },
 }
 
+# Mailman API credentials
+MAILMAN_REST_API_URL = env("MAILMAN_REST_API_URL", default="http://localhost:8001")
+MAILMAN_REST_API_USER = env("MAILMAN_REST_API_USER", default="restadmin")
+MAILMAN_REST_API_PASS = env("MAILMAN_REST_API_PASS", default="restpass")
+MAILMAN_ARCHIVER_KEY = env("MAILMAN_ARCHIVER_KEY", default="password")
+MAILMAN_ELASTIC_INDEX = env("MAILMAN_ELASTIC_INDEX", default="haystack")
+MAILMAN_HAYSTACK_URL = env("MAILMAN_HAYSTACK_URL", default="http://127.0.0.1:9200/")
 
+# Must still be configured:
 HAYSTACK_CONNECTIONS = {
     "default": {
-        "ENGINE": "haystack.backends.simple_backend.SimpleEngine",
+        "ENGINE": "haystack.backends.elasticsearch7_backend.Elasticsearch7SearchEngine",
+        "URL": MAILMAN_HAYSTACK_URL,
+        "INDEX_NAME": MAILMAN_ELASTIC_INDEX,
     },
 }
 

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -133,6 +133,36 @@ Env:
         key: key
   - name: MAILGUN_SENDER_DOMAIN
     value: cppal-dev.boost.cppalliance.org
+  - name: MAILMAN_REST_API_URL
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_url
+  - name: MAILMAN_REST_API_USER
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_user
+  - name: MAILMAN_REST_API_PASS
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_pass
+  - name: MAILMAN_ARCHIVER_KEY
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: archiver_key
+  - name: MAILMAN_ELASTIC_INDEX
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: elastic_index
+  - name: MAILMAN_HAYSTACK_URL
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: haystack_url
   - name: GITHUB_TOKEN
     valueFrom:
       secretKeyRef:
@@ -175,6 +205,15 @@ hostAliases:
   - ip: "10.67.224.3"
     hostnames:
       - "redis"
+  - ip: "10.128.0.15"
+    hostnames:
+      - "mailman.boost.cppalliance.org"
+  - ip: "10.128.15.240"
+    hostnames:
+      - "mailman-stage.boost.cppalliance.org"
+  - ip: "10.128.0.16"
+    hostnames:
+      - "mailman-cppal-dev.boost.cppalliance.org"
 
 ingressType: gce
 managedCertName: managed-cert-cppal-dev,managed-cert-cppal-dev2

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -133,6 +133,36 @@ Env:
         key: key
   - name: MAILGUN_SENDER_DOMAIN
     value: boost.cppalliance.org
+  - name: MAILMAN_REST_API_URL
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_url
+  - name: MAILMAN_REST_API_USER
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_user
+  - name: MAILMAN_REST_API_PASS
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_pass
+  - name: MAILMAN_ARCHIVER_KEY
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: archiver_key
+  - name: MAILMAN_ELASTIC_INDEX
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: elastic_index
+  - name: MAILMAN_HAYSTACK_URL
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: haystack_url
   - name: GITHUB_TOKEN
     valueFrom:
       secretKeyRef:
@@ -175,6 +205,15 @@ hostAliases:
   - ip: "10.67.224.20"
     hostnames:
       - "redis"
+  - ip: "10.128.0.15"
+    hostnames:
+      - "mailman.boost.cppalliance.org"
+  - ip: "10.128.15.240"
+    hostnames:
+      - "mailman-stage.boost.cppalliance.org"
+  - ip: "10.128.0.16"
+    hostnames:
+      - "mailman-cppal-dev.boost.cppalliance.org"
 
 ingressType: gce
 managedCertName: managed-cert-boost-production,managed-cert-boost-production2

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -133,6 +133,36 @@ Env:
         key: key
   - name: MAILGUN_SENDER_DOMAIN
     value: stage.boost.cppalliance.org
+  - name: MAILMAN_REST_API_URL
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_url
+  - name: MAILMAN_REST_API_USER
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_user
+  - name: MAILMAN_REST_API_PASS
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_pass
+  - name: MAILMAN_ARCHIVER_KEY
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: archiver_key
+  - name: MAILMAN_ELASTIC_INDEX
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: elastic_index
+  - name: MAILMAN_HAYSTACK_URL
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: haystack_url
   - name: GITHUB_TOKEN
     valueFrom:
       secretKeyRef:
@@ -175,6 +205,15 @@ hostAliases:
   - ip: "10.67.224.11"
     hostnames:
       - "redis"
+  - ip: "10.128.0.15"
+    hostnames:
+      - "mailman.boost.cppalliance.org"
+  - ip: "10.128.15.240"
+    hostnames:
+      - "mailman-stage.boost.cppalliance.org"
+  - ip: "10.128.0.16"
+    hostnames:
+      - "mailman-cppal-dev.boost.cppalliance.org"
 
 ingressType: gce
 managedCertName: managed-cert-boost-stage,managed-cert-boost-stage2

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -128,6 +128,36 @@ Env:
       secretKeyRef:
         name: mailgun
         key: key
+  - name: MAILMAN_REST_API_URL
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_url
+  - name: MAILMAN_REST_API_USER
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_user
+  - name: MAILMAN_REST_API_PASS
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: api_pass
+  - name: MAILMAN_ARCHIVER_KEY
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: archiver_key
+  - name: MAILMAN_ELASTIC_INDEX
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: elastic_index
+  - name: MAILMAN_HAYSTACK_URL
+    valueFrom:
+      secretKeyRef:
+        name: mailman
+        key: haystack_url
   - name: GITHUB_TOKEN
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
Don't merge without creating a k8s secret, I will send the file.

This pull request adds Django variables pointing to mailman3 servers.

Main tasks to include mailman3 in the project:

- Install mailman3-core servers on dedicated VMs in Google Cloud.  They are running. There is a mailman core instance for each environment (stage, production, revsys).  Separate database, different from Django.

- Add mailman3-web front-end to the Django project. Use the same set of user accounts, passwords, database, etc. This front-end web integration still remains to be done, Nessita was working on that.

What's provided here are secrets and variables allowing web to reach mailman-core. If you would like to ssh into the servers we can set up access.
