### PR TITLE
Import maintainers when there are no maintainers

### DIFF
--- a/libraries/management/commands/import_library_versions.py
+++ b/libraries/management/commands/import_library_versions.py
@@ -172,7 +172,8 @@ def handle_library_version(version, library, maintainers, updater):
         f"Saved library version {library_version}. Created? {created}", fg="green"
     )
 
-    if created:
+    # If the library version has no maintainers, we need to update the maintainers
+    if library_version.maintainers.count() == 0:
         updater.update_maintainers(library_version, maintainers=maintainers)
         click.secho(f"Updated maintainers for {library_version}.", fg="green")
 


### PR DESCRIPTION
closes #616 

The problem was that when `import_library_versions` runs and loads the maintainers, it only tries to load them if the `LibraryVersion` was created. Since older versions of WinAPI had maintainers, and my local db had maintainers for the current version, it looks like the LibraryVersion for WinAPI-1.82.0 was probably created, but for whatever reasons its maintainers didn't load. And on subsequent runs of this import, the maintainers wouldn't be attempted since the LibraryVersion record already existed. 

I changed the logic to try and import maintainers if there aren't any, regardless of whether the LibraryVersion record is new. 

Once this is merged, `./manage.py import_library_versions --min-release=1.82` will need to be run in deployed environments. 