### PR TITLE
Add setting for minimum Boost version to import

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -427,3 +427,7 @@ CORS_ALLOW_HEADERS = (
 ARTIFACTORY_URL = env(
     "ARTIFACTORY_URL", default="https://boostorg.jfrog.io/artifactory/api/storage/main/"
 )
+
+# The min Boost version is the oldest version of Boost that our import scripts
+# will retrieve. It's determined by the files we store in the archives/ in S3.
+MINIMUM_BOOST_VERSION = "1.31.0"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,7 +39,7 @@ This command retrieves and stores the documentation URLs for specific or all lib
 Here are the options you can use:
 
 - `--version`: Specify the version for which you want to retrieve documentation URLs. You can provide a specific version number (example: '1.81.0') or a partial version number to process all versions that contain the partial version number (example: '--version=1.7' would process 1.70.0, 1.71.0, 1.72.0, etc.). If no version is specified, all active versions will be processed.
-- `--min-version`: Specify the minimum version for which you want to retrieve documentation URLs. The default is "1.30.0".
+- `--min-version`: Specify the minimum version for which you want to retrieve documentation URLs. The default is defined in the settings file.
 
 ### Example:
 
@@ -68,7 +68,7 @@ Connect Library objects to the Boost versions (AKA "release") that included them
 Here are the options you can use:
 
 - `--release`: Full or partial Boost version (release) number. If `release` is passed, the command will import all libraries for the versions that contain the passed-in release number. If not passed, the command will import libraries for all active versions newer than the min-release.
-- `--min-release`: Specify the minimum version for which you want to retrieve documentation URLs. The default is "1.30.0".
+- `--min-release`: Specify the minimum version for which you want to retrieve documentation URLs. The default is defined in the settings file.
 - `--token`: Pass a GitHub API token. If not passed, will use the value in `settings.GITHUB_TOKEN`.
 
 ### Example:

--- a/libraries/management/commands/import_library_version_docs_urls.py
+++ b/libraries/management/commands/import_library_version_docs_urls.py
@@ -1,5 +1,7 @@
 import djclick as click
 
+from django.conf import settings
+
 from libraries.models import LibraryVersion
 from libraries.tasks import get_and_store_library_version_documentation_urls_for_version
 from versions.models import Version
@@ -17,7 +19,7 @@ from versions.models import Version
 @click.option(
     "--min-version",
     type=str,
-    default="1.30.0",
+    default=settings.MIN_BOOST_VERSION,
     help="Minimum Boost version to process (default: 1.30.0)",
 )
 def command(version, min_version):

--- a/libraries/management/commands/import_library_versions.py
+++ b/libraries/management/commands/import_library_versions.py
@@ -1,5 +1,7 @@
 import djclick as click
 
+from django.conf import settings
+
 from libraries.github import LibraryUpdater
 from core.githubhelper import GithubAPIClient, GithubDataParser
 from libraries.models import Library, LibraryVersion
@@ -14,7 +16,7 @@ from versions.models import Version
 @click.option(
     "--min-release",
     type=str,
-    default="1.30.0",
+    default=settings.MIN_BOOST_VERSION,
     help="Minimum Boost version to process (default: 1.30.0)",
 )
 def command(min_release, release, token):

--- a/versions/management/commands/import_versions.py
+++ b/versions/management/commands/import_versions.py
@@ -1,5 +1,6 @@
 import djclick as click
 
+from django.conf import settings
 from django.core.management import call_command
 from fastcore.xtras import obj2dict
 
@@ -7,8 +8,6 @@ from core.githubhelper import GithubAPIClient
 from versions.models import Version
 from versions.tasks import get_release_date_for_version
 
-# Minimum Boost version to import
-MIN_BOOST_VERSION = "1.10.3"
 
 # Skip beta releases, release candidates, and pre-1.0 versions
 EXCLUSIONS = ["beta", "-rc"]
@@ -93,7 +92,7 @@ def skip_tag(name):
 
     # If this version is too old, skip it
     version_num = name.replace("boost-", "")
-    if version_num < MIN_BOOST_VERSION:
+    if version_num < settings.MIN_BOOST_VERSION:
         return True
 
     return False


### PR DESCRIPTION
Per our meeting on 9/1, this PR sets the oldest Boost version to import to the oldest we have docs for in S3. The oldest we store is 1.31.0 -- see screenshot. 

![Screenshot 2023-09-07 at 1 50 55 PM](https://github.com/cppalliance/temp-site/assets/2286304/0e3a3f0e-449f-434d-b16d-b73af08a5605)
