### PR TITLE
Remove unused url, unused template logic

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -25,7 +25,6 @@ from libraries.views import (
     LibraryDetail,
     LibraryList,
     LibraryListByCategory,
-    LibraryListByCategoryMini,
     LibraryListMini,
 )
 from mailing_list.views import MailingListDetailView, MailingListView
@@ -103,11 +102,6 @@ urlpatterns = (
             "donate/",
             TemplateView.as_view(template_name="donate/donate.html"),
             name="donate",
-        ),
-        path(
-            "libraries/by-category/mini/",
-            LibraryListByCategoryMini.as_view(),
-            name="libraries-by-category-mini",
         ),
         path(
             "libraries/by-category/",

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -101,13 +101,6 @@ def test_library_list_by_category(
     assert "libraries" in res.context["library_list"][0]
 
 
-def test_library_list_by_category_mini(library_version, category, tp):
-    """GET /libraries/by-category/mini/"""
-    test_library_list_by_category(
-        library_version, category, tp, url="libraries-by-category-mini"
-    )
-
-
 def test_library_detail(library_version, tp):
     """GET /libraries/{slug}/"""
     library = library_version.library

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -107,7 +107,6 @@ class LibraryListByCategory(LibraryList):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["by_category"] = True
         context["library_list"] = self.get_results_by_category()
         return context
 
@@ -122,12 +121,6 @@ class LibraryListByCategory(LibraryList):
                 }
             )
         return results_by_category
-
-
-class LibraryListByCategoryMini(LibraryListByCategory):
-    """Flat list version of LibraryListByCategory"""
-
-    template_name = "libraries/list.html"
 
 
 class LibraryDetail(FormMixin, DetailView):

--- a/templates/libraries/category_list.html
+++ b/templates/libraries/category_list.html
@@ -78,8 +78,7 @@
 
   {# Libraries list #}
   <div class="space-y-3">
-    {% if by_category %}
-      {% for result in library_list %}
+    {% for result in library_list %}
       <div class="relative content-between p-3 w-full bg-white rounded-lg shadow-lg md:p-5 dark:bg-charcoal">
         <h5 class="mb-2 pb-2 text-2xl font-bold leading-tight text-orange border-b border-gray-300 dark:border-slate">{{ result.category }}</h5>
         <table class="table-auto w-full">
@@ -92,16 +91,7 @@
           </tbody>
         </table>
       </div>
-      {% endfor %}
-    {% else %}
-      <table class="table-auto w-full">
-        <tbody>
-        {% for library in library_list %}
-          {% include "libraries/_library_category_list_item.html" %}
-        {% endfor %}
-        </tbody>
-      </table>
-    {% endif %}
+    {% endfor %}
   </div>
   {# end libraries list #}
 

--- a/templates/libraries/flat_list.html
+++ b/templates/libraries/flat_list.html
@@ -78,29 +78,16 @@
 
   {# Libraries list #}
   <div class="relative content-between p-3 w-full bg-white rounded-lg shadow-lg md:p-5 dark:bg-charcoal">
-    {% if by_category %}
-      {% for result in library_list %}
-        <h2>{{ result.category }}</h2>
-        <table class="table-auto w-full">
-          <tbody>
-          {% for library in result.libraries %}
-            {% include "libraries/_library_flat_list_item.html" %}
-          {% endfor %}
-          </tbody>
-        </table>
-      {% endfor %}
-    {% else %}
-      {% if category %}
-        <h5 class="pb-2 text-2xl font-bold leading-tight text-orange border-b border-gray-300 dark:border-slate">{{ category }}</h5>
-      {% endif %}
-      <table class="table-auto w-full">
-        <tbody>
-        {% for library in library_list %}
-          {% include "libraries/_library_flat_list_item.html" %}
-        {% endfor %}
-        </tbody>
-      </table>
+    {% if category %}
+      <h5 class="pb-2 text-2xl font-bold leading-tight text-orange border-b border-gray-300 dark:border-slate">{{ category }}</h5>
     {% endif %}
+    <table class="table-auto w-full">
+      <tbody>
+      {% for library in library_list %}
+        {% include "libraries/_library_flat_list_item.html" %}
+      {% endfor %}
+      </tbody>
+    </table>
   </div>
   {# end libraries list #}
 

--- a/templates/libraries/list.html
+++ b/templates/libraries/list.html
@@ -77,19 +77,9 @@
 
   {# Libraries list #}
   <div class="grid grid-cols-1 gap-4 mb-5 md:grid-cols-2 lg:grid-cols-3">
-    {# todo/?: is by_category still possible here? #}
-    {% if by_category %}
-      {% for result in library_list %}
-        <h2>{{ result.category }}</h2>
-        {% for library in result.libraries %}
-          {% include "libraries/_library_list_item.html" %}
-        {% endfor %}
-      {% endfor %}
-    {% else %}
-      {% for library in library_list %}
-        {% include "libraries/_library_list_item.html" %}
-      {% endfor %}
-    {% endif %}
+    {% for library in library_list %}
+      {% include "libraries/_library_list_item.html" %}
+    {% endfor %}
   </div>
   {# end libraries list #}
 


### PR DESCRIPTION
- Removes the `by_category` from library list templates and from the view 
- Removes the library list mini category template, view, and url route; no longer used 