### PR TITLE
Quote helm ImageTag to force string type

### DIFF
--- a/.github/workflows/actions-gcp.yaml
+++ b/.github/workflows/actions-gcp.yaml
@@ -183,6 +183,6 @@ jobs:
           set -xe
           TAG=${{ env.SHORT_SHA }}
           cd kube/boost
-          helm upgrade --install --create-namespace -n ${{ env.K8S_NAMESPACE }} -f values-${{ env.K8S_NAMESPACE }}-gke.yaml --timeout=3600s --set=Image=${DOCKER_IMAGE} --set=ImageTag="${TAG}" ${{ env.HELM_RELEASE_NAME }} .
+          helm upgrade --install --create-namespace -n ${{ env.K8S_NAMESPACE }} -f values-${{ env.K8S_NAMESPACE }}-gke.yaml --timeout=3600s --set=Image=${DOCKER_IMAGE} --set-string ImageTag="${TAG}" ${{ env.HELM_RELEASE_NAME }} .
           kubectl rollout status deployment/$DEPLOYMENT_NAME -n ${{ env.K8S_NAMESPACE }}
           kubectl get services -o wide -n ${{ env.K8S_NAMESPACE }}

--- a/kube/boost/templates/celery.yaml
+++ b/kube/boost/templates/celery.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         app: celery-worker
         env: {{.Values.deploymentEnvironment}}
-        imageTag: {{.Values.ImageTag}}
+        imageTag: "{{.Values.ImageTag}}"
     spec:
 {{- if .Values.hostAliases }}
       hostAliases:
@@ -63,7 +63,7 @@ spec:
       labels:
         app: celery-beat
         env: {{.Values.deploymentEnvironment}}
-        imageTag: {{.Values.ImageTag}}
+        imageTag: "{{.Values.ImageTag}}"
     spec:
 {{- if .Values.hostAliases }}
       hostAliases:

--- a/kube/boost/templates/deployment.yaml
+++ b/kube/boost/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app: boost
         env: {{.Values.deploymentEnvironment}}
-        imageTag: {{.Values.ImageTag}}
+        imageTag: "{{.Values.ImageTag}}"
 {{- include "InitAnnotation" . | indent 8 }}
     spec:
 {{- if .Values.hostAliases }}

--- a/kube/boost/templates/service.yaml
+++ b/kube/boost/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: boost
   labels:
     env: {{ .Values.deploymentEnvironment }}
-    image: {{ .Values.ImageTag }}
+    image: "{{ .Values.ImageTag }}"
 spec:
   ports:
     - port: 80


### PR DESCRIPTION
If the commit SHA is used as an ImageTag and happens to be numeric, helm interprets that is a number instead of a string.  To solve the issue quote the "ImageTag" value.

