### PR TITLE
Add fqdn3, new preview DNS domain

### DIFF
--- a/kube/boost/templates/configmap-nginx.yaml
+++ b/kube/boost/templates/configmap-nginx.yaml
@@ -18,8 +18,14 @@ data:
     }
 
     server {
+      listen 80;
+      server_name {{.Values.publicFqdn3}};
+      return 301 $scheme://www.{{.Values.publicFqdn3}}$request_uri;
+    }
+
+    server {
       listen 80 deferred default;
-      server_name www.{{.Values.publicFqdn}} www.{{.Values.publicFqdn2}} ;
+      server_name www.{{.Values.publicFqdn}} www.{{.Values.publicFqdn2}} www.{{.Values.publicFqdn3}} ;
 
       error_log /dev/stdout info;
       access_log /dev/stdout main;

--- a/kube/boost/templates/ingress.yaml
+++ b/kube/boost/templates/ingress.yaml
@@ -23,7 +23,7 @@ spec:
       secretName: www.{{.Values.publicFqdn}}-tls
   rules:
     - host: www.{{.Values.publicFqdn}}
-      http:
+      http: &http_rules
         paths:
           - path: /
             pathType: Prefix
@@ -33,35 +33,15 @@ spec:
                 port:
                   number: 80
     - host: {{ .Values.publicFqdn }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: boost
-                port:
-                  number: 80
+      http: *http_rules
     - host: www.{{.Values.publicFqdn2 }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: boost
-                port:
-                  number: 80
+      http: *http_rules
     - host: {{ .Values.publicFqdn2 }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: boost
-                port:
-                  number: 80
+      http: *http_rules
+    - host: www.{{.Values.publicFqdn3 }}
+      http: *http_rules
+    - host: {{ .Values.publicFqdn3 }}
+      http: *http_rules
 
 {{- else if eq .Values.ingressType "gce" }}
 
@@ -87,7 +67,7 @@ spec:
     - secretName: {{ .Values.secretCertName }}
   rules:
     - host: www.{{.Values.publicFqdn}}
-      http:
+      http: &http_rules_gcp
         paths:
           - path: /
             pathType: Prefix
@@ -97,35 +77,15 @@ spec:
                 port:
                   number: 80
     - host: {{ .Values.publicFqdn }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: boost
-                port:
-                  number: 80
+      http: *http_rules_gcp
     - host: www.{{.Values.publicFqdn2 }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: boost
-                port:
-                  number: 80
+      http: *http_rules_gcp
     - host: {{ .Values.publicFqdn2 }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: boost
-                port:
-                  number: 80
+      http: *http_rules_gcp
+    - host: www.{{.Values.publicFqdn3 }}
+      http: *http_rules_gcp
+    - host: {{ .Values.publicFqdn3 }}
+      http: *http_rules_gcp
 ---
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -23,6 +23,7 @@ initCommands:
 
 publicFqdn: &fqdn cppal-dev.boost.cppalliance.org
 publicFqdn2: &fqdn2 boost.org
+publicFqdn3: &fqdn3 cppal-dev2.boost.cppalliance.org
 
 Env:
   - name: DJANGO_SETTINGS_MODULE
@@ -55,9 +56,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "cppal-dev.boost.cppalliance.org, www.cppal-dev.boost.cppalliance.org, boost.org, www.boost.org"
+    value: "cppal-dev.boost.cppalliance.org, www.cppal-dev.boost.cppalliance.org, boost.org, www.boost.org, cppal-dev2.boost.cppalliance.org, www.cppal-dev2.boost.cppalliance.org"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://0.0.0.0, http://localhost, https://cppal-dev.boost.cppalliance.org, https://www.cppal-dev.boost.cppalliance.org, https://boost.org, https://www.boost.org"
+    value: "http://0.0.0.0, http://localhost, https://cppal-dev.boost.cppalliance.org, https://www.cppal-dev.boost.cppalliance.org, https://boost.org, https://www.boost.org, https://cppal-dev2.boost.cppalliance.org, https://www.cppal-dev2.boost.cppalliance.org"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS
@@ -174,7 +175,7 @@ hostAliases:
       - "redis"
 
 ingressType: gce
-managedCertName: managed-cert-cppal-dev
+managedCertName: managed-cert-cppal-dev,managed-cert-cppal-dev2
 secretCertName: boostorgcert
 ingressStaticIp: cppal-dev-ingress1
 redisInstall: false

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -23,6 +23,7 @@ initCommands:
 
 publicFqdn: &fqdn boost.cppalliance.org
 publicFqdn2: &fqdn2 boost.org
+publicFqdn3: &fqdn3 preview.boost.org
 
 Env:
   - name: DJANGO_SETTINGS_MODULE
@@ -55,9 +56,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "boost.cppalliance.org, www.boost.cppalliance.org, boost.org, www.boost.org"
+    value: "boost.cppalliance.org, www.boost.cppalliance.org, boost.org, www.boost.org, preview.boost.org, www.preview.boost.org"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://0.0.0.0, http://localhost, https://boost.cppalliance.org, https://www.boost.cppalliance.org, https://boost.org, https://www.boost.org"
+    value: "http://0.0.0.0, http://localhost, https://boost.cppalliance.org, https://www.boost.cppalliance.org, https://boost.org, https://www.boost.org, https://preview.boost.org, https://www.preview.boost.org"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS
@@ -174,7 +175,7 @@ hostAliases:
       - "redis"
 
 ingressType: gce
-managedCertName: managed-cert-boost-production
+managedCertName: managed-cert-boost-production,managed-cert-boost-production2
 secretCertName: boostorgcert
 ingressStaticIp: boost-production-ingress1
 redisInstall: false

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -23,6 +23,7 @@ initCommands:
 
 publicFqdn: &fqdn stage.boost.cppalliance.org
 publicFqdn2: &fqdn2 stage.boost.org
+publicFqdn3: &fqdn3 stage2.boost.cppalliance.org
 
 Env:
   - name: DJANGO_SETTINGS_MODULE
@@ -55,9 +56,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "stage.boost.cppalliance.org, www.stage.boost.cppalliance.org, stage.boost.org, www.stage.boost.org"
+    value: "stage.boost.cppalliance.org, www.stage.boost.cppalliance.org, stage.boost.org, www.stage.boost.org, stage2.boost.cppalliance.org, www.stage2.boost.cppalliance.org"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://0.0.0.0, http://localhost, https://stage.boost.cppalliance.org, https://www.stage.boost.cppalliance.org, https://stage.boost.org, https://www.stage.boost.org"
+    value: "http://0.0.0.0, http://localhost, https://stage.boost.cppalliance.org, https://www.stage.boost.cppalliance.org, https://stage.boost.org, https://www.stage.boost.org, https://stage2.boost.cppalliance.org, https://www.stage2.boost.cppalliance.org"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS
@@ -174,7 +175,7 @@ hostAliases:
       - "redis"
 
 ingressType: gce
-managedCertName: managed-cert-boost-stage
+managedCertName: managed-cert-boost-stage,managed-cert-boost-stage2
 secretCertName: boostorgcert
 ingressStaticIp: boost-stage-ingress1
 redisInstall: false

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -23,6 +23,7 @@ initCommands:
 
 publicFqdn: &fqdn boost.revsys.dev
 publicFqdn2: &fqdn2 boost.org
+publicFqdn3: &fqdn3 preview.boost.org
 
 Env:
   - name: DJANGO_SETTINGS_MODULE
@@ -55,9 +56,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "boost.revsys.dev, www.boost.revsys.dev, boost.org, www.boost.org"
+    value: "boost.revsys.dev, www.boost.revsys.dev, boost.org, www.boost.org, preview.boost.org, www.preview.boost.org"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://0.0.0.0, http://localhost, https://boost.revsys.dev, https://www.boost.revsys.dev, https://boost.org, https://www.boost.org"
+    value: "http://0.0.0.0, http://localhost, https://boost.revsys.dev, https://www.boost.revsys.dev, https://boost.org, https://www.boost.org, https://preview.boost.org, https://www.preview.boost.org"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS


### PR DESCRIPTION
A new domain preview.boost.org is being added. 
DNS updates are pending. 
Most of the web changes, although not all, can be made in advance by adding a `fqdn3` to the kube files as a placeholder.