### PR TITLE
MAILGUN_SENDER_DOMAIN variable

### DIFF
--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -131,6 +131,8 @@ Env:
       secretKeyRef:
         name: mailgun
         key: key
+  - name: MAILGUN_SENDER_DOMAIN
+    value: cppal-dev.boost.cppalliance.org
   - name: GITHUB_TOKEN
     valueFrom:
       secretKeyRef:

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -131,6 +131,8 @@ Env:
       secretKeyRef:
         name: mailgun
         key: key
+  - name: MAILGUN_SENDER_DOMAIN
+    value: boost.cppalliance.org
   - name: GITHUB_TOKEN
     valueFrom:
       secretKeyRef:

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -131,6 +131,8 @@ Env:
       secretKeyRef:
         name: mailgun
         key: key
+  - name: MAILGUN_SENDER_DOMAIN
+    value: stage.boost.cppalliance.org
   - name: GITHUB_TOKEN
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
MAILGUN_API_KEY depends on MAILGUN_SENDER_DOMAIN, so adding that now.

Eventually the domain should be switched to a "boost.org" domain, but that can be done later when the domains names have stabilized.

