### PR TITLE
[WIP but ready for review] Allow maintainers and authors to claim their User accounts by resetting their passwords 

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -51,6 +51,7 @@ from support.views import SupportView
 from users.views import (
     CurrentUserAPIView,
     CurrentUserProfileView,
+    CustomSignupView,
     ProfileView,
     UserViewSet,
 )
@@ -69,6 +70,7 @@ urlpatterns = (
         path("", HomepageView.as_view(), name="home"),
         path("homepage-beta/", HomepageBetaView.as_view(), name="home-beta"),
         path("admin/", admin.site.urls),
+        path("accounts/signup/", CustomSignupView.as_view(), name="account_signup"),
         path("accounts/", include("allauth.urls")),
         path("users/me/", CurrentUserProfileView.as_view(), name="profile-account"),
         path("users/<int:pk>/", ProfileView.as_view(), name="profile-user"),


### PR DESCRIPTION
Note to self: see the `#TODO` comments for what to finish in the morning. 

### Paths that work: 

✅ A new user with a new email address: registers fine 

✅ Password mismatch: shows error 

✅ Invalid email: shows error 

❓ What would happen if one of these people just went straight to the Forgot Password and didn’t attempt to sign up?  Would it work, or would it fail because the account hasn’t been claimed?  _Exopected behavior: it works, and the account is marked as claimed. Need to test._ 

✅ Existing user who is `claimed`, meaning they interacted with their account in some way: shows the expected error that an account already exists, but doesn't send the password reset email 
![Screenshot 2023-09-29 at 10 41 18 AM](https://github.com/cppalliance/temp-site/assets/2286304/5edeb574-d10b-44b8-aa56-fa9b9bc04a0d)

✅ Existing user who is not `claimed`, meaning they were imported as a maintainer or author: receives a password reset email, is shown a message that they have an existing account and will receive a password reset email, and is redirected to the login screen 

Text of message: 
> An account already exists for you. Check your email for instructions on resetting your password so you can claim your account.

![Screenshot 2023-09-29 at 10 43 35 AM](https://github.com/cppalliance/temp-site/assets/2286304/71b3a64b-f926-4f40-a7a3-2ad11177a78a)

Text of the password reset email (this is the default): 

```
Content-Type: text/plain; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit
Subject: [localhost:8000] Password Reset E-mail
From: news@boost.org
To: maintainer@example.com
Date: Fri, 29 Sep 2023 17:43:30 -0000
Message-ID: <169600941089.541.9001068802991968879@b8c537329eac>

Hello from localhost:8000!

You're receiving this e-mail because you or someone else has requested a password for your user account.
It can be safely ignored if you did not request a password reset. Click the link below to reset your password.

http://localhost:8000/accounts/password/reset/key/2y4-bvauki-89addb2ea8e91d0cb93711254e3115d1/

Thank you for using localhost:8000!
localhost:8000
```

### Remaining tasks 

- [ ] When an unclaimed user resets their password successfully, mark their account as `claimed`  
- [ ] Deal with social auth once we discuss process in the meeting 
- [ ] Update "from" email for password reset.


### Notes 

- [ ] When a user registers with social auth (github, google), and they enter an email that matches an unclaimed user, right now, they get an error that the email address is already in use, and they should log in with that email address, then connect their social account. If they are a maintainer, the instructions are basically the same, except they need to request a password reset for that email, then log in and connect their social account. Should i add those instructions to the same message, or should I go ahead and show them a different message? And/or, should I send the password reset email automatically, if it's an unclaimed maintainer account? 
- [ ] Custom text for these maintainer/author password reset emails? 
- [ ] Future imports -- we should consider how future releases will also contain `libraries.json` files that don't map directly to user accounts (people use multiple emails, or are part of multiple orgs depending on the libs they work in etc.). We already save the `libraries.json` data on the `LibraryVersion` record, which will be helpful in matching. But a future enhancement might be allowing a user to have multiple Author and Maintainer records, or adding field(s) to the User model to capture what's stored in the `libraries.json` files of the libs they work with. Something to make matching the `libraries.json` to the real Users easier. 
- [ ] What should our `from` email be? Apparently right now it's `news@boost.org`. 
- Doesn't deal with social auth yet -- separate PR 