### PR TITLE
Change DEFAULT_FROM_EMAIL and SERVER_EMAIL

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -387,8 +387,8 @@ NEWS_MODERATION_ALLOWLIST = [
 # EMAIL SETTINGS -- THESE NEED ADJUSTMENT WHEN DECIDED WHICH ESP WILL BE USED
 EMAIL_HOST = "maildev"
 EMAIL_PORT = 1025
-DEFAULT_FROM_EMAIL = "news@boost.org"
-SERVER_EMAIL = "errors@boost.org"
+DEFAULT_FROM_EMAIL = "info@cppalliance.org"
+SERVER_EMAIL = "errors@cppalliance.org"
 
 # Deployed email configuration
 if LOCAL_DEVELOPMENT:


### PR DESCRIPTION
Part of #667. Updates `DEFAULT_FROM_EMAIL = "info@cppalliance.org"` and `SERVER_EMAIL = "errors@cppalliance.org"` 