### PR TITLE
Allow user to claim account via social auth/password reset when trying to connect

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -51,6 +51,7 @@ from support.views import SupportView
 from users.views import (
     CurrentUserAPIView,
     CurrentUserProfileView,
+    CustomSocialSignupViewView,
     CustomSignupView,
     ProfileView,
     UserViewSet,
@@ -70,6 +71,11 @@ urlpatterns = (
         path("", HomepageView.as_view(), name="home"),
         path("homepage-beta/", HomepageBetaView.as_view(), name="home-beta"),
         path("admin/", admin.site.urls),
+        path(
+            "accounts/social/signup/",
+            CustomSocialSignupViewView.as_view(),
+            name="socialaccount_signup",
+        ),
         path("accounts/signup/", CustomSignupView.as_view(), name="account_signup"),
         path("accounts/", include("allauth.urls")),
         path("users/me/", CurrentUserProfileView.as_view(), name="profile-account"),

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -148,3 +148,27 @@ def test_current_user_profile_view_post_valid_preferences(
     assert_messages(
         response, [("success", "Your preferences were successfully updated.")]
     )
+
+
+# Test for ClaimExistingAccountMixin
+
+
+@pytest.mark.skip(
+    reason="Not actually hitting the endpoint; did a live test locally instead. FIXME."
+)
+@pytest.mark.django_db
+def test_CustomSocialSignupViewView_existing_unclaimed_account(client, rf, user, tp):
+    """
+    Test if an existing but unclaimed account receives a password reset email.
+    """
+    user.claimed = False
+    user.save()
+    user.refresh_from_db()
+    form_data = {"email": user.email}
+
+    # Act
+    response = client.post(
+        tp.reverse("socialaccount_signup"), data=form_data, follow=True
+    )
+
+    assert response.status_code == 200


### PR DESCRIPTION
Part of #667 

Commented out the test -- it passes, but some `breakpoint()` indicate that it isn't actually testing anything. I did a live test, though, and was able to: 

- Have a user who is not `claimed` with the same email address as my gmail account
- Try to connect as a new user via that gmail account 
- See a message that there is an account for me already 
- Get an email with the reset password link, reset the password, log in, then connect my Gmail account from my profile 
- Sign out, then sign in with email address and password 
- Sign out, then sign in with gmail 
- Confirm in the admin that the accounts are linked appropriately 


How to test: 

- Log into the admin with your admin account and create a new User.
- Enter the email and password x2. Select “save and continue editing.”
- On the User screen, uncheck Claimed and save the record.
- Now, in a new browser window, you can try to sign up with the email address you just created