### PR TITLE
Set STATIC_CONTENT_REGION env variable

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -372,7 +372,12 @@ STATIC_CONTENT_AWS_SECRET_ACCESS_KEY = env(
     "STATIC_CONTENT_AWS_SECRET_ACCESS_KEY", default="changeme"
 )
 STATIC_CONTENT_BUCKET_NAME = env("STATIC_CONTENT_BUCKET_NAME", default="changeme")
-STATIC_CONTENT_AWS_S3_ENDPOINT_URL = "s3.amazonaws.com"
+
+STATIC_CONTENT_REGION = env("STATIC_CONTENT_REGION", default="us-east-2")
+
+STATIC_CONTENT_AWS_S3_ENDPOINT_URL = env(
+    "STATIC_CONTENT_AWS_S3_ENDPOINT_URL", default="https://s3.us-east-2.amazonaws.com"
+)
 
 # Markdown content
 BASE_CONTENT = env("BOOST_CONTENT_DIRECTORY", "/website")

--- a/core/boostrenderer.py
+++ b/core/boostrenderer.py
@@ -131,7 +131,7 @@ def get_s3_client():
         "s3",
         aws_access_key_id=settings.STATIC_CONTENT_AWS_ACCESS_KEY_ID,
         aws_secret_access_key=settings.STATIC_CONTENT_AWS_SECRET_ACCESS_KEY,
-        region_name="us-east-1",
+        region_name=settings.STATIC_CONTENT_REGION,
     )
 
 


### PR DESCRIPTION
Testing "Import New Releases". 

Log output appears in the celery worker.   

```
[2023-10-05 18:44:57,723: DEBUG/ForkPoolWorker-4] Response body:
b'<?xml version="1.0" encoding="UTF-8"?>\n<Error><Code>AuthorizationHeaderMalformed</Code><Message>The authorization header is malformed; the region \'us-east-1\' is wrong; expecting \'us-east-2\'</Message><Region>us-east-2</Region><RequestId>34HBXRSHVQ27BM9Q</RequestId><HostId>nsaJb0o4kTICyagzUAT3SIA2WTmn9u6px/KiJX1IFRgGWRyoWfi9kClu7TDRMqjF1hBnIZO0VLA=</HostId></Error>'

[2023-10-05 18:44:57,727: DEBUG/ForkPoolWorker-4] S3 client configured for region us-east-1 but the bucket boost.org-cppal-dev-v2 is in region us-east-2; Please configure the proper region to avoid multiple unnecessary redirects and signing attempts.
```

To fix those, the function `get_s3_client()` can take either a region_name or an endpoint_url.  It seems that setting the region_name is the most effective method.  
