### PR TITLE
Set CPU on deployment

### DIFF
--- a/kube/boost/templates/deployment.yaml
+++ b/kube/boost/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
       containers:
         -
           name: wsgi
+          resources:
+{{- toYaml .Values.wsgiResources | nindent 12 }}
           image: {{.Values.Image}}:{{.Values.ImageTag}}
           volumeMounts:
 {{ toYaml .Values.VolumeMounts | indent 12 }}

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -10,6 +10,16 @@ clientMaxBodySize: 250m
 
 replicaCount: "2"
 
+wsgiResources:
+  limits:
+    cpu: "500m"
+    ephemeral-storage: 1Gi
+    memory: 2Gi
+  requests:
+    cpu: "500m"
+    ephemeral-storage: 1Gi
+    memory: 2Gi
+
 ## NOTE ##
 # set publcFqdn to the target domain. `www` will be prepended to the domain
 # where necessary

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -10,6 +10,16 @@ clientMaxBodySize: 250m
 
 replicaCount: "2"
 
+wsgiResources:
+  limits:
+    cpu: "1"
+    ephemeral-storage: 1Gi
+    memory: 2Gi
+  requests:
+    cpu: "1"
+    ephemeral-storage: 1Gi
+    memory: 2Gi
+
 ## NOTE ##
 # set publcFqdn to the target domain. `www` will be prepended to the domain
 # where necessary

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -10,6 +10,16 @@ clientMaxBodySize: 250m
 
 replicaCount: "2"
 
+wsgiResources:
+  limits:
+    cpu: "1"
+    ephemeral-storage: 1Gi
+    memory: 2Gi
+  requests:
+    cpu: "1"
+    ephemeral-storage: 1Gi
+    memory: 2Gi
+
 ## NOTE ##
 # set publcFqdn to the target domain. `www` will be prepended to the domain
 # where necessary

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -10,6 +10,16 @@ clientMaxBodySize: 250m
 
 replicaCount: "2"
 
+wsgiResources:
+  limits:
+    cpu: "1"
+    ephemeral-storage: 1Gi
+    memory: 2Gi
+  requests:
+    cpu: "1"
+    ephemeral-storage: 1Gi
+    memory: 2Gi
+
 ## NOTE ##
 # set publcFqdn to the target domain. `www` will be prepended to the domain
 # where necessary


### PR DESCRIPTION
Set the memory, cpu, and storage on the django pod.  Currently setting all environments to a low number (1 CPU) , this can be modified at any time, especially when the number of users is likely to increase.  