### PR TITLE
:bug: only show if authenticated

### DIFF
--- a/templates/news/list.html
+++ b/templates/news/list.html
@@ -174,7 +174,9 @@
           </div>
         </div>
         {% empty %}
-        <p class="text-center">No news yet; consider submitting something!</p>
+          {% if  user.is_authenticated %}
+            <p class="text-center">No news yet; consider submitting something!</p>
+          {% endif %}
         {% endfor %}
       </div>
     </div>


### PR DESCRIPTION
If the user is not authenticated don’t show an alert to submit something when news list is empty.

Issue: #537