### PR TITLE
Add better messaging, more graceful handling when no data has been imported 

### DIFF
--- a/libraries/mixins.py
+++ b/libraries/mixins.py
@@ -12,23 +12,23 @@ class VersionAlertMixin:
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        # Get the version from the GET parameters or default to the latest
+        latest_version = Version.objects.most_recent()
         version_slug = self.request.GET.get(
-            "version", Version.objects.most_recent().slug
+            "version", latest_version.slug if latest_version else None
         )
 
-        try:
-            selected_version = Version.objects.get(slug=version_slug)
-        except Version.DoesNotExist:
-            selected_version = Version.objects.most_recent()
+        selected_version = None
+        if version_slug:
+            try:
+                selected_version = Version.objects.get(slug=version_slug)
+            except Version.DoesNotExist:
+                selected_version = latest_version
 
-        # compare the selected version with the latest version
-        latest_version = Version.objects.most_recent()
         context["latest_version"] = latest_version
         context["version"] = selected_version
 
-        if selected_version != latest_version:
-            context["version_alert"] = True
+        if selected_version and latest_version:
+            context["version_alert"] = selected_version != latest_version
         else:
             context["version_alert"] = False
 

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -5,6 +5,9 @@ from dateutil.relativedelta import relativedelta
 
 from model_bakery import baker
 
+from ..models import Library
+from versions.models import Version
+
 
 def test_library_list(library_version, tp, url_name="libraries"):
     """GET /libraries/"""
@@ -32,9 +35,25 @@ def test_library_list(library_version, tp, url_name="libraries"):
     assert v_no_libraries not in res.context["versions"]
 
 
+def test_library_list_no_data(tp):
+    """GET /libraries/"""
+    Library.objects.all().delete()
+    Version.objects.all().delete()
+    res = tp.get("libraries")
+    tp.response_200(res)
+
+
 def test_library_list_mini(library_version, tp):
     """GET /libraries/mini/"""
     test_library_list(library_version, tp, url_name="libraries-mini")
+
+
+def test_library_list_mini_no_data(tp):
+    """GET /libraries/"""
+    Library.objects.all().delete()
+    Version.objects.all().delete()
+    res = tp.get("libraries-mini")
+    tp.response_200(res)
 
 
 def test_library_list_no_pagination(library_version, tp):

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -146,8 +146,9 @@
     </div>
 
     <div class="my-4 space-y-4 lg:flex lg:my-16 lg:space-y-0 lg:space-x-4">
+      {% if featured_library %}
       <div class="p-4 relative bg-white rounded lg:p-11 lg:w-1/2 dark:bg-charcoal min-h-[500px]">
-        {% if featured_library %}
+
           <div class="mb-6">
             <span class="inline py-1 px-3 w-auto text-sm uppercase rounded md:text-base text-green bg-green/10">library spotlight</span>
           </div>
@@ -198,8 +199,9 @@
             </div>
           </div>
           {% endcomment %}
-        {% endif %}
+
       </div>
+      {% endif %}
       <div class="p-4 relative bg-white rounded lg:p-11 lg:w-1/2 dark:bg-charcoal min-h-[500px]">
         <div class="mb-6">
           <span class="inline py-1 px-3 w-auto text-sm uppercase rounded md:text-base text-green bg-green/10">recent news</span>

--- a/templates/libraries/list.html
+++ b/templates/libraries/list.html
@@ -7,6 +7,7 @@
 
 {% block content %}
 <main class="content">
+  {% if library_list %}
   <div class="py-0 px-0 mt-0 mb-0 w-full md:mb-2 flex flex-row flex-nowrap items-center md:block">
     <div class="flex-auto mb-2 w-full md:block md:w-auto md:mb-0">
       <div>
@@ -98,5 +99,6 @@
   {# end pagination #}
   {% endif %}
 
+  {% endif %}
 </main>
 {% endblock %}

--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -6,10 +6,12 @@
 {% block description %}{% blocktrans with version_name=version.display_name %}Discover what's new in Boost {{ version_name }}{% endblocktrans %}{% endblock %}
 {% block content %}
   <main class="content">
+    {% if version %}
     <div class="py-0 px-0 mb-0 w-full md:mb-2 flex flex-row flex-nowrap items-center"
             x-data="{'showSearch': false}"
             x-on:keydown.escape="showSearch=false">
       <div class="flex-auto mb-2 w-full">
+
         <div>
           <span class="text-xl md:text-3xl lg:text-4xl">
             {% if is_current_release %}
@@ -138,5 +140,6 @@
         </div>
       </div>
     </section>
+  {% endif %}
   </main>
 {% endblock %}

--- a/versions/tests/test_views.py
+++ b/versions/tests/test_views.py
@@ -1,10 +1,9 @@
-import pytest
 from datetime import timedelta
 from django.utils import timezone
 from model_bakery import baker
+from ..models import Version
 
 
-@pytest.mark.skip("TODO: Fix. Live behavior is fine, but test fails")
 def test_version_most_recent_detail(version, tp):
     """
     GET /releases/
@@ -12,10 +11,18 @@ def test_version_most_recent_detail(version, tp):
     now = timezone.now()
 
     ten_years_ago = now - timedelta(days=365 * 10)
-    baker.make("versions.Version", release_date=ten_years_ago)
+    baker.make("versions.Version", name="boost-0.0.0", release_date=ten_years_ago)
     res = tp.get_check_200("releases-most-recent")
     assert "versions" in res.context
     assert res.context["version"] == version
+
+
+def test_version_detail_no_data(tp):
+    """
+    GET /releases/
+    """
+    Version.objects.all().delete()
+    tp.get_check_200("releases-most-recent")
 
 
 def test_version_detail(version, tp):

--- a/versions/views.py
+++ b/versions/views.py
@@ -3,6 +3,7 @@ import structlog
 from django.views.generic import DetailView
 from django.views.generic.edit import FormMixin
 from django.shortcuts import redirect
+from django.contrib import messages
 from itertools import groupby
 from operator import attrgetter
 
@@ -23,6 +24,20 @@ class VersionDetail(FormMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
         obj = self.get_object()
+
+        # Handle the case where no data has been uploaded
+        if not obj:
+            messages.add_message(
+                self.request,
+                messages.WARNING,
+                "No data has been imported yet. Please check back later.",
+            )
+            context["versions"] = None
+            context["downloads"] = None
+            context["current_release"] = None
+            context["is_current_release"] = False
+            return context
+
         context["versions"] = Version.objects.version_dropdown()
         downloads = obj.downloads.all().order_by("operating_system")
         context["downloads"] = {


### PR DESCRIPTION
Closes #700 

- Hides rest of template for releases page and libraries list page when there is no data 
- Adds message that there is no data that is appropriate for prod but lets a local developer know what the issue is 
- Hides "featured library" block when there is no featured library 


![Screenshot 2023-10-18 at 3 09 47 PM](https://github.com/cppalliance/temp-site/assets/2286304/8914395e-b6a3-4e56-9b36-4942133570a3)
![Screenshot 2023-10-18 at 3 09 41 PM](https://github.com/cppalliance/temp-site/assets/2286304/3f9a701b-f814-454c-936b-87bed32e20ee)

![Screenshot 2023-10-18 at 3 20 23 PM](https://github.com/cppalliance/temp-site/assets/2286304/3095b9fc-4c70-4736-abae-eb7ae05a9b44)
