### PR TITLE
Fix our custom 404 page 

### DIFF
--- a/ak/views.py
+++ b/ak/views.py
@@ -144,6 +144,10 @@ class NotFoundView(View):
         raise Http404("404 Not Found")
 
 
+def custom_404_view(request, exception=None):
+    return render(request, "404.html", status=404)
+
+
 class OKView(View):
     def get(self, *args, **kwargs):
         return HttpResponse("200 OK", status=200)

--- a/config/urls.py
+++ b/config/urls.py
@@ -270,3 +270,5 @@ urlpatterns = (
         ),
     ]
 )
+
+handler404 = "ak.views.custom_404_view"

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -4,6 +4,7 @@ import pytest
 from django.core.cache import caches
 from django.test import RequestFactory
 from django.test.utils import override_settings
+from django.http import Http404
 
 from core.views import StaticContentTemplateView
 
@@ -71,12 +72,13 @@ def test_content_found(request_factory):
 @override_settings(
     CACHES=TEST_CACHES,
 )
-def test_content_not_found(request_factory):
+def test_content_not_found(tp, request_factory):
     """Test that a 404 response is returned for nonexistent content."""
     content_path = "/nonexistent/file.html"
-    with patch("core.views.get_content_from_s3", return_value=None):
-        response = call_view(request_factory, content_path)
-    assert response.status_code == 404
+
+    with patch("core.views.get_content_from_s3", side_effect=Http404):
+        with pytest.raises(Http404):
+            call_view(request_factory, content_path)
 
 
 @pytest.mark.django_db
@@ -197,7 +199,6 @@ def test_docs_libs_gateway_404(tp, mock_get_file_data):
     mock_get_file_data("<html></html>", "a-url")
 
     response = tp.get("docs-libs-page", content_path="other-url")
-
     tp.response_404(response)
 
 

--- a/core/views.py
+++ b/core/views.py
@@ -118,7 +118,7 @@ class MarkdownTemplateView(TemplateView):
                 content_path=kwargs.get("content_path"),
                 status_code=404,
             )
-            raise Http404("Page not found")
+            raise Http404("Markdown not found")
 
         if not os.path.isfile(path):
             logger.info(
@@ -175,7 +175,7 @@ class StaticContentTemplateView(TemplateView):
                 content_path=content_path,
                 status_code=404,
             )
-            return HttpResponseNotFound("Page not found")
+            raise Http404("Content not found")
         return super().get(request, *args, **kwargs)
 
     def cache_result(self, static_content_cache, cache_key, result):


### PR DESCRIPTION
Part of #724, closes to #175 

- Corrects an issue where a 404 status code was being returned in a convoluted way 
- Enforces our 404 template as the one to use any time a 404 is raised 
- Fixes some tests 