### PR TITLE
Dependency for elasticsearch + Updates to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ using:
 $ docker compose down
 ```
 
+### :bell: Updating the Docker image with new dependencies
+
+> If new dependencies exist in `requirements.in`, see [Dependency Management](docs/dependencies.md) for details on how to rebuild the Docker image with those new dependencies.
+
 ## Running the tests
 
 To run the tests, execute:

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -6,4 +6,4 @@
 1. Add the package to `requirements.in`
 1. Run `just pip-compile`, which will add the dependency to `requirements.txt`
 1. Run `just rebuild` to rebuild your Docker image to include the new dependencies
-2. Run `just up` and continue with development
+2. Run `docker compose up` and continue with development

--- a/requirements.in
+++ b/requirements.in
@@ -58,6 +58,7 @@ beautifulsoup4
 
 django-haystack>=3.2
 django-mptt==0.14
+elasticsearch==7.17.9
 
 # Github
 ghapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ celery==5.2.7
     # via -r ./requirements.in
 certifi==2023.5.7
     # via
+    #   elasticsearch
     #   minio
     #   requests
 cffi==1.15.1
@@ -139,6 +140,8 @@ djangorestframework==3.14.0
     # via
     #   -r ./requirements.in
     #   django-rest-auth
+elasticsearch==7.17.9
+    # via -r ./requirements.in
 environs[django]==9.5.0
     # via -r ./requirements.in
 executing==1.2.0
@@ -315,6 +318,7 @@ urllib3==1.26.16
     # via
     #   botocore
     #   django-anymail
+    #   elasticsearch
     #   minio
     #   requests
     #   responses


### PR DESCRIPTION
- Adds elasticsearch with necessary version into requirements.in and requirements.txt
- Updated the dependency management doc to use `docker compose up` for the final command since `just up` is not valid
- Updated root README to include section to direct people to the dependency management doc

Resolves #746 