### PR TITLE
Slack out, many style updates

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1230,6 +1230,10 @@ code,
   right: 0.25rem;
 }
 
+.top-6 {
+  top: 1.5rem;
+}
+
 .isolate {
   isolation: isolate;
 }
@@ -1730,6 +1734,10 @@ code,
 
 .w-4 {
   width: 1rem;
+}
+
+.w-28 {
+  width: 7rem;
 }
 
 .min-w-full {
@@ -3805,6 +3813,14 @@ code,
     margin-bottom: 2.5rem;
   }
 
+  .lg\:mr-10 {
+    margin-right: 2.5rem;
+  }
+
+  .lg\:mr-4 {
+    margin-right: 1rem;
+  }
+
   .lg\:flex {
     display: flex;
   }
@@ -3877,6 +3893,18 @@ code,
     --tw-space-x-reverse: 0;
     margin-right: calc(1.25rem * var(--tw-space-x-reverse));
     margin-left: calc(1.25rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(1.5rem * var(--tw-space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .lg\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(3rem * var(--tw-space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .lg\:rounded-tl-lg {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1166,8 +1166,8 @@ code,
   right: 0px;
 }
 
-.top-1 {
-  top: 0.25rem;
+.top-6 {
+  top: 1.5rem;
 }
 
 .right-8 {
@@ -1230,8 +1230,8 @@ code,
   right: 0.25rem;
 }
 
-.top-6 {
-  top: 1.5rem;
+.top-1 {
+  top: 0.25rem;
 }
 
 .isolate {
@@ -1626,6 +1626,15 @@ code,
   width: 50%;
 }
 
+.w-fit {
+  width: -moz-fit-content;
+  width: fit-content;
+}
+
+.w-28 {
+  width: 7rem;
+}
+
 .w-6 {
   width: 1.5rem;
 }
@@ -1673,11 +1682,6 @@ code,
 
 .w-2\/3 {
   width: 66.666667%;
-}
-
-.w-fit {
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .w-\[100px\] {
@@ -1734,10 +1738,6 @@ code,
 
 .w-4 {
   width: 1rem;
-}
-
-.w-28 {
-  width: 7rem;
 }
 
 .min-w-full {
@@ -2417,11 +2417,6 @@ code,
   padding-bottom: 1rem;
 }
 
-.px-2 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-
 .px-12 {
   padding-left: 3rem;
   padding-right: 3rem;
@@ -2482,6 +2477,11 @@ code,
   padding-right: 5rem;
 }
 
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
 .px-\[40px\] {
   padding-left: 40px;
   padding-right: 40px;
@@ -2504,6 +2504,10 @@ code,
 
 .pb-1 {
   padding-bottom: 0.25rem;
+}
+
+.pt-3 {
+  padding-top: 0.75rem;
 }
 
 .pt-2 {
@@ -2542,8 +2546,8 @@ code,
   padding-top: 2rem;
 }
 
-.pr-4 {
-  padding-right: 1rem;
+.pr-2 {
+  padding-right: 0.5rem;
 }
 
 .pb-10 {
@@ -2560,10 +2564,6 @@ code,
 
 .pt-1 {
   padding-top: 0.25rem;
-}
-
-.pr-2 {
-  padding-right: 0.5rem;
 }
 
 .pt-0 {
@@ -2588,10 +2588,6 @@ code,
 
 .pt-4 {
   padding-top: 1rem;
-}
-
-.pt-3 {
-  padding-top: 0.75rem;
 }
 
 .pb-3 {
@@ -2665,14 +2661,14 @@ code,
   line-height: 1.5rem;
 }
 
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
 .text-xl {
   font-size: 1.25rem;
   line-height: 1.75rem;
-}
-
-.text-3xl {
-  font-size: 1.875rem;
-  line-height: 2.25rem;
 }
 
 .text-lg {
@@ -2685,14 +2681,14 @@ code,
   line-height: 2.5rem;
 }
 
+.text-3xl {
+  font-size: 1.875rem;
+  line-height: 2.25rem;
+}
+
 .text-sm {
   font-size: 0.875rem;
   line-height: 1.25rem;
-}
-
-.text-xs {
-  font-size: 0.75rem;
-  line-height: 1rem;
 }
 
 .font-bold {
@@ -3805,20 +3801,12 @@ code,
     margin-bottom: 4rem;
   }
 
-  .lg\:mr-16 {
-    margin-right: 4rem;
+  .lg\:mr-4 {
+    margin-right: 1rem;
   }
 
   .lg\:mb-10 {
     margin-bottom: 2.5rem;
-  }
-
-  .lg\:mr-10 {
-    margin-right: 2.5rem;
-  }
-
-  .lg\:mr-4 {
-    margin-right: 1rem;
   }
 
   .lg\:flex {
@@ -3877,6 +3865,12 @@ code,
     margin-bottom: calc(0px * var(--tw-space-y-reverse));
   }
 
+  .lg\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(3rem * var(--tw-space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
   .lg\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --tw-space-x-reverse: 0;
     margin-right: calc(1rem * var(--tw-space-x-reverse));
@@ -3893,18 +3887,6 @@ code,
     --tw-space-x-reverse: 0;
     margin-right: calc(1.25rem * var(--tw-space-x-reverse));
     margin-left: calc(1.25rem * calc(1 - var(--tw-space-x-reverse)));
-  }
-
-  .lg\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
-    --tw-space-x-reverse: 0;
-    margin-right: calc(1.5rem * var(--tw-space-x-reverse));
-    margin-left: calc(1.5rem * calc(1 - var(--tw-space-x-reverse)));
-  }
-
-  .lg\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
-    --tw-space-x-reverse: 0;
-    margin-right: calc(3rem * var(--tw-space-x-reverse));
-    margin-left: calc(3rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .lg\:rounded-tl-lg {

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
 {% load i18n %}
+
+{% load widget_tweaks %}
 {% load account socialaccount %}
 {% load static %}
 
@@ -77,7 +79,7 @@
                 {% for field in form.visible_fields %}
                   <div>
                     <label class="text-xs uppercase text-slate dark:text-white/70" for="{{ field.id_for_label }}">{{ field.label }}{% if field.widget_type == 'checkbox' %}&nbsp;&nbsp;{% endif %}
-                    {{ field }}
+                      {% render_field field placeholder="" %}
                     </label>
                     {% if field.help_text %}
                       <small>{{ field.help_text }}</small>

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 
+{% load widget_tweaks %}
 {% load account socialaccount %}
 
 {% block head_title %}{% trans "Sign Up" %}{% endblock %}
@@ -55,7 +56,7 @@
                   {% endif %}
                   <div>
                     <label class="text-xs uppercase text-slate dark:text-white/70">{{ field.label }}
-                      {{ field }}
+                      {% render_field field placeholder="" %}
                     </label>
 
                     {% if field.help_text %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,7 +34,7 @@
     <meta class="meta-theme" name="theme-color" content="#FAFAFA" data-dark="#18181B" data-light="#FAFAFA" />
     <meta class="meta-theme" name="color-scheme" content="light" data-dark="dark" data-light="light" />
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.css" />
     <script src="https://cdn.jsdelivr.net/npm/@ryangjchandler/alpine-clipboard@2.x.x/dist/alpine-clipboard.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@alpinejs/persist@3.x.x/dist/cdn.min.js" defer></script>
     <script src="//unpkg.com/alpinejs" defer></script>

--- a/templates/community_temp.html
+++ b/templates/community_temp.html
@@ -9,8 +9,10 @@
     <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
 
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
-        <h5 class="text-2xl font-bold leading-tight text-orange">Mailing Lists</h5>
-        <p class="py-1 my-2 border-b border-gray-700">Better your understanding of Boost and C++: join or explore the archives of our mailing list, a humble space where enthusiasts share insights and engage in meaningful dialogue.</p>
+        <h5 class="text-2xl leading-tight text-orange">Mailing Lists</h5>
+        <p class="py-1 my-2 border-b border-gray-700">
+          Discover the Boost library community with options tailored to developers, casual users, and enthusiasts.
+        </p>
         <div class="grid grid-cols-2 lg:grid-cols-3">
 
           <a href="https://lists.boost.org/mailman/listinfo.cgi/boost" class="p-3 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">
@@ -33,18 +35,15 @@
       </div>
 
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
-        <h5 class="text-2xl font-bold leading-tight text-orange">Discussion Forums</h5>
-        <p class="py-1 my-2 border-b border-gray-700"></p>
+        <h5 class="text-2xl leading-tight text-orange">Discussion Forums</h5>
+        <p class="py-1 my-2 border-b border-gray-700">
+          Coming soon, exploring the topics and decisions being made by the community will be available via a more modern interface.
+        </p>
 
-        <div class="w-full text-center">
-        <h2>Coming Soon!</h2>
-        </div>
-
-        <div>In the meantime, please enjoy our <a href="https://lists.boost.org/Archives/boost/" class="whitespace-nowrap">Mailing List Archives</a></div>
-
-
+        <div class="text-center mx-auto pt-3">In the meantime, please enjoy our<br /><a href="https://lists.boost.org/Archives/boost/" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange whitespace-nowrap">Mailing List Archives</a></div>
       </div>
 
+      {% comment %}
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
         <h5 class="text-2xl font-bold leading-tight text-orange">Official C++ Language Slack Workspace</h5>
 
@@ -54,9 +53,10 @@
           <a href="https://cppalliance.org/slack/" class="flex p-3 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">Join C++ Slack</a>
           <a href="https://cpplang.slack.com/" class="flex p-3 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">Visit the Workspace</a>
           </div>
-
       </div>
+      {% endcomment %}
 
+      {% comment %}
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
         <h5
             class="text-2xl font-bold leading-tight text-orange">
@@ -70,23 +70,23 @@
             <li class="w-1/2 text-center"><a href="https://www.boost.org/users/memoriam/beman_dawes.html" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">In Memoriam: Beman Dawes</a></li>
           </ul>
       </div>
+      {% endcomment %}
 
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
-        <h5 class="text-2xl font-bold leading-tight text-orange">Twitter</h5>
-        <p class="py-1 my-2 border-b border-gray-700">Follow us, like, and retweet announcements and informative updates about Boost and C++.</p>
-        <br />
-        <a href="https://twitter.com/boost_libraries" class="block p-3 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">Official Boost Twitter<br /><i class="fa-brands fa-twitter fa-3x"></i></a>
+        <h5 class="text-2xl leading-tight text-orange">ISO C++</h5>
+        <p class="py-1 my-2 border-b border-gray-700">News, Status & Discussion about Standard C++</p>
+        <p class="pt-3"><a href="https://isocpp.org/" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange whitespace-nowrap">The Standard C++ Foundation</a> is a Washington 501(c)(6) not-for-profit organization supporting the C++ community and promotes the use of modern Standard C++.</p>
       </div>
 
       <div class="p-6 text-white bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
-        <h5 class="text-2xl font-bold leading-tight text-orange">ISO C++</h5>
-        <p class="py-1 border-b border-gray-700">News, Status & Discussion about Standard C++</p>
-        <p>The Standard C++ Foundation (Standard CPP Foundation in some databases that don’t support + in names) is a Washington 501(c)(6) not-for-profit organization whose purpose is to support the C++ software developer community and promote the understanding and use of modern Standard C++ on all compilers and platforms.</p>
-
-
-          <a href="https://isocpp.org/" class="flex p-3 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">Visit the ISO C++ Site</a>
-
+        <h5 class="text-2xl leading-tight text-orange">Across the Web</h5>
+        <p class="py-1 my-2 border-b border-gray-700">Follow us, like, and share our announcements.</p>
+        <div class="grid grid-cols-2 justify-items-center w-fit mx-auto">
+          <a href="https://github.com/boostorg" class="block p-3 w-28 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"><span class="text-xs">On GitHub</span> <br /><i class="fa-brands fa-github fa-3x"></i></a>
+          <a href="https://x.com/boost_libraries" class="block p-3 w-28 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"><span class="text-xs">On X (fka Twitter)</span> <br /><i class="fa-brands fa-x-twitter fa-3x"></i></a>
+        </div>
       </div>
+
     </div>
   </div>
 {% endblock %}

--- a/templates/docs_temp.html
+++ b/templates/docs_temp.html
@@ -23,13 +23,12 @@ make the columns go to 1
 
     <div class="pt-6 grid grid-cols-1 lg:grid-cols-2 gap-y-0 lg:gap-y-5 grid-flow-row auto-rows-min">
 
-      <div class="order-2 lg:order-1 p-4 dark:text-white text-slate bg-white lg:rounded-tl-lg dark:bg-charcoal dark:bg-neutral-700">
-        <h5
-            class="text-3xl font-bold leading-tight text-orange mb-2">
+      <div class="order-2 lg:order-1 p-6 dark:text-white text-slate bg-white lg:rounded-tl-lg dark:bg-charcoal dark:bg-neutral-700">
+          <h5 class="text-2xl leading-tight text-orange">
             <a href="/doc/user-guide/index.html" class="link-header">User Guide</a>
           </h5>
-          <p class="text-xl py-1 border-b border-gray-700">How to use the libraries in your programs</p>
-          <div class="grid grid-cols-2 gap-2 mt-6 text-xl">
+          <p class="text-lg py-1 border-b border-gray-700">How to use the libraries in your programs</p>
+          <div class="grid grid-cols-2 gap-2 mt-6 text-lg">
 
             <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/user-guide/intro.html"><i class="mt-1 mr-2 fas fa-book inline-block w-6 text-center"></i>Intro to Boost</a></div>
             <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/user-guide/getting-started.html"><i class="mt-1 mr-2 fas fa-school inline-block w-6 text-center"></i>Getting Started</a></div>
@@ -43,7 +42,7 @@ make the columns go to 1
             <div class="w-auto ml-6 mr-2 col-span-2 md:col-span-1"><a class="list-item text-base text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/user-guide/resources.html">Additional Resources</a></div>
           </div>
       </div>
-      <div class="order-1 lg:order-2 p-4 dark:text-white text-slate bg-white lg:rounded-tr-lg dark:bg-charcoal dark:bg-neutral-700 min-h-96 max-h-96 lg:max-h-max overflow-y-hidden">
+      <div class="order-1 lg:order-2 p-6 dark:text-white text-slate bg-white lg:rounded-tr-lg dark:bg-charcoal dark:bg-neutral-700 min-h-96 max-h-96 lg:max-h-max overflow-y-hidden">
         <a href="/doc/user-guide/">
           <img
             class="lg:rounded-tr-lg object-cover object-center min-w-full min-h-full h-full border border-gray-100 dark:border-0"
@@ -54,13 +53,15 @@ make the columns go to 1
         </a>
       </div>
 
+      {% comment %}
       <div class="order-3 my-5 lg:my-0 w-auto col-span-1 lg:col-span-2  dark:text-white text-slate bg-transparent">
         <div class="w-4/6 p-4 mx-auto text-center bg-green/40 rounded-lg text-lg">
           <i class="fab fa-xl fa-slack"></i> You can also find help by <a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="https://cppalliance.org/slack/">joining the C++ Slack</a> and then <a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="https://cpplang.slack.com/">visiting the workspace</a>.
         </div>
       </div>
+      {% endcomment %}
 
-      <div class="order-4 p-4 dark:text-white text-slate bg-white lg:rounded-tl-lg lg:rounded-bl-lg dark:bg-charcoal dark:bg-neutral-700 min-h-96 max-h-96 lg:max-h-max overflow-y-hidden">
+      <div class="order-4 p-6 dark:text-white text-slate bg-white lg:rounded-tl-lg lg:rounded-bl-lg dark:bg-charcoal dark:bg-neutral-700 min-h-96 max-h-96 lg:max-h-max overflow-y-hidden">
         <a href="/doc/contributor-guide/">
           <img
             class="lg:rounded-tr-lg object-cover object-bottom min-w-full min-h-full h-full border border-gray-100 dark:border-0"
@@ -70,13 +71,12 @@ make the columns go to 1
             alt="Contributor Guide" />
         </a>
       </div>
-      <div class="order-5 p-4 pl-8 dark:text-white text-slate bg-white lg:rounded-tr-lg lg:rounded-br-lg dark:bg-charcoal dark:bg-neutral-700">
-        <h5
-        class="text-3xl font-bold leading-tight text-orange mb-2">
+      <div class="order-5 p-6 pl-8 dark:text-white text-slate bg-white lg:rounded-tr-lg lg:rounded-br-lg dark:bg-charcoal dark:bg-neutral-700">
+          <h5 class="text-2xl leading-tight text-orange">
             <a href="/doc/contributor-guide/index.html" class="link-header">Contributor Guide</a>
           </h5>
           <p class="text-xl py-1 border-b border-gray-700">Resources to help you contribute</p>
-          <div class="grid grid-cols-2 gap-2 mt-6 text-xl">
+          <div class="grid grid-cols-2 gap-2 mt-6 text-lg">
 
             <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/getting-involved.html"><i class="mt-1 mr-2 far fa-handshake inline-block w-6 text-center"></i>Getting Involved</a></div>
             <div class="w-full col-span-2 md:col-span-1"><a class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/contributor-guide/design-guide/design-guide.html"><i class="mt-1 mr-2 fas fa-diagram-project inline-block w-6 text-center"></i>Design Guide</a></div>
@@ -92,15 +92,14 @@ make the columns go to 1
 
       </div>
 
-      <div class="order-7 lg:order-6 p-4 dark:text-white text-slate bg-white lg:rounded-bl-lg dark:bg-charcoal dark:bg-neutral-700">
-        <h5
-        class="text-3xl font-bold leading-tight text-orange mb-2">
+      <div class="order-7 lg:order-6 p-6 dark:text-white text-slate bg-white lg:rounded-bl-lg dark:bg-charcoal dark:bg-neutral-700">
+         <h5 class="text-2xl leading-tight text-orange">
             <a href="/doc/formal-reviews/index.html" class="link-header">Boost Formal Reviews</a>
           </h5>
           <p class="text-xl py-1 border-b border-gray-700">
             Learn how new libraries are added
           </p>
-          <div class="grid grid-cols-1 gap-4 mt-6 text-xl pl-4">
+          <div class="grid grid-cols-1 gap-4 mt-6 text-lg pl-4">
             <div class="w-auto ml-6 mr-2"><a class="list-item text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/formal-reviews/index.html">Introduction</a></div>
             <div class="w-auto ml-6 mr-2"><a class="list-item text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/formal-reviews/submissions.html">Submission Process</a></div>
             <div class="w-auto ml-6 mr-2"><a class="list-item text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange" href="/doc/formal-reviews/writing-reviews.html">Write a Review</a></div>
@@ -108,7 +107,7 @@ make the columns go to 1
           </div>
 
       </div>
-      <div class="order-6 lg:order-7 p-4 dark:text-white text-slate bg-white lg:rounded-br-lg dark:bg-charcoal dark:bg-neutral-700 min-h-96 max-h-96 lg:max-h-max overflow-y-hidden">
+      <div class="order-6 lg:order-7 p-6 dark:text-white text-slate bg-white lg:rounded-br-lg dark:bg-charcoal dark:bg-neutral-700 min-h-96 max-h-96 lg:max-h-max overflow-y-hidden">
         <a href="/doc/formal-reviews/">
           <img
             class="lg:rounded-tr-lg object-cover object-center min-w-full min-h-full h-full border border-gray-100 dark:border-0"

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -24,11 +24,11 @@
       </div>
     </div>
 
-    <div class="px-2 dark:text-white text-slate bg-white rounded-lg dark:bg-charcoal dark:bg-neutral-700">
-      <div class="py-4 px-2 y-16 lg:flex">
+    <div class="p-6 dark:text-white text-slate bg-white rounded-lg dark:bg-charcoal dark:bg-neutral-700">
+      <div class="lg:flex">
         <div class="lg:order-last lg:w-1/2 px-4 pt-2">
           <h5
-          class="text-3xl font-bold leading-tight text-orange mb-2">Boost Mission</h5>
+          class="text-3xl leading-tight text-orange mb-2">Boost Mission</h5>
           <ul class="mb-0 pl-2 ml-6 space-y-2 list-disc">
           <li>development of high quality, expert reviewed, legally unencumbered, open-source libraries,</li>
           <li>inspiring standard enhancements, and</li>
@@ -39,7 +39,7 @@
           <div>
           </div>
         </div>
-        <div class="flex lg:mr-16 my-auto pt-8 lg:w-1/2 justify-center">
+        <div class="flex lg:mr-4 my-auto pt-8 lg:w-1/2 justify-center">
           <div class="grid grid-cols-2 w-full justify-items-center">
             <div class="items-center text-center px-4">
               <img class="mx-auto mb-2" src="{% static 'img/icons/icon-download-grn.svg' %}" alt="Downloads" />
@@ -51,7 +51,7 @@
               <h4 class="mb-3 text-5xl">165+</h4>
               Individual Libraries
             </div>
-            <div class="col-span-2 items-center w-full text-left pl-4 pr-4">
+            <div class="col-span-2 items-center w-full text-left pl-4 pr-2">
               <p><span class="text-xl font-bold">Why Use Boost?</span>&nbsp;&nbsp; In a word, <i>Productivity</i>. Use of high-quality libraries like Boost speeds initial development, results in fewer bugs, reduces reinvention-of-the-wheel, and cuts long-term maintenance costs. And since Boost libraries tend to become de facto or de jure standards, many programmers are already familiar with them.</p>
             </div>
           </div>
@@ -68,20 +68,10 @@
         </div>
         <div class="flex flex-col justify-center items-center pb-4 h-full">
           <div class="relative mx-auto w-4/5"
-               x-data="{ activeSlide: 1, slides: [1, 2, 3] }">
+               x-data="{ activeSlide: 1, slides: [1, 2] }">
             <!-- Slides -->
-            <div x-show="activeSlide === 1"
-                 class="flex items-center py-0 px-12 h-full rounded-lg">
-              <div class="w-full">
-                <h3 class="pb-2 mb-2 text-2xl capitalize border-b border-gray-400 text-orange dark:border-slate">October 2023</h3>
-                <span class="pb-1 mx-auto w-full text-sm align-left">
-                  <strong>Wednesday October 25th:</strong> Boost 1.84.0 closed for new libraries and breaking changes
-                  <br />
-                  <div class="pt-1 pl-4 font-light">Release branch is closed for new libraries and breaking changes to existing libraries. Still open for bug fixes and other routine changes to all libraries without release manager review.</div>
-                </span>
-              </div>
-            </div>
-            <div x-show="activeSlide === 2" x-cloak
+
+            <div x-show="activeSlide === 1" x-cloak
                  class="flex items-center py-0 px-12 h-full rounded-lg">
               <div class="w-full">
                 <h3 class="pb-2 mb-2 text-2xl capitalize border-b border-gray-400 text-orange dark:border-slate">November 2023</h3>
@@ -111,7 +101,7 @@
                 </span>
               </div>
             </div>
-            <div x-show="activeSlide === 3" x-cloak
+            <div x-show="activeSlide === 2" x-cloak
                  class="flex items-center py-0 px-12 h-full rounded-lg">
               <div class="w-full">
                 <h3 class="pb-2 mb-2 text-2xl capitalize border-b border-gray-400 text-orange dark:border-slate">December 2023</h3>
@@ -145,14 +135,14 @@
       </div>
     </div>
 
-    <div class="my-4 space-y-4 lg:flex lg:my-16 lg:space-y-0 lg:space-x-4">
+    <div class="my-4 space-y-4 lg:flex lg:my-16 lg:space-y-0 lg:space-x-12">
       {% if featured_library %}
       <div class="p-6 relative bg-white rounded-lg md:p-11 lg:w-1/2 dark:bg-charcoal min-h-[500px]">
 
           <div class="mb-6">
             <span class="inline py-1 px-3 w-auto text-sm uppercase rounded md:text-base text-[rgb(14,174,96)] dark:text-green font-semibold bg-gray-300/50 dark:bg-green/10 border border-orange/30">library spotlight</span>
           </div>
-          <div class="absolute top-1 right-8 p-2 group">
+          <div class="absolute top-6 right-8 p-2 group">
             <a href="{% url 'libraries' %}"
                class="text-sm font-medium md:text-base lg:text-base  text-sky-600 dark:text-sky-300 group-hover:text-orange dark:group-hover:text-orange">
               All Libraries&nbsp;<i class="fas fa-chevron-right  text-sky-600 dark:text-sky-300 group-hover:text-orange dark:group-hover:text-orange"></i>
@@ -206,7 +196,7 @@
         <div class="mb-6">
           <span class="inline py-1 px-3 w-auto text-sm uppercase rounded md:text-base text-[rgb(14,174,96)] dark:text-green font-semibold bg-gray-300/50 dark:bg-green/10 border border-orange/30">recent news</span>
         </div>
-        <div class="absolute top-1 right-8 p-2 group">
+        <div class="absolute top-6 right-8 p-2 group">
           <a href="{% url 'news' %}"
             class="text-sm font-medium md:text-base lg:text-base text-sky-600 dark:text-sky-300 group-hover:text-orange dark:group-hover:text-orange">
             All News&nbsp;<i class="fas fa-chevron-right text-sky-600 dark:text-sky-300 group-hover:text-orange dark:group-hover:text-orange"></i>
@@ -228,7 +218,7 @@
     </div>
 
     <div class="my-4 space-y-4 lg:flex lg:my-16 lg:space-y-0 lg:space-x-4">
-      <div class="p-4 bg-white rounded-lg md:p-11 w-full dark:bg-charcoal">
+      <div class="p-6 bg-white rounded-lg md:p-11 w-full dark:bg-charcoal">
         <div class="mb-6">
           <span class="inline py-1 px-3 w-auto text-sm uppercase rounded md:text-base text-[rgb(14,174,96)] dark:text-green font-semibold bg-gray-300/50 dark:bg-green/10 border border-orange/30">featured video</span>
         </div>

--- a/templates/includes/_header.html
+++ b/templates/includes/_header.html
@@ -310,6 +310,11 @@
 
             <a href="{% url 'releases-most-recent' %}" class="block py-2 px-3 text-slate dark:text-white">Releases</a>
           </div>
+          <div class="px-2 pt-6 pb-3 text-base">
+            <a href="/doc/user-guide/index.html" class="block py-2 px-3 text-slate dark:text-white">User Guide</a>
+            <a href="/doc/contributor-guide/index.html" class="block py-2 px-3 text-slate dark:text-white">Contributor Guide</a>
+            <a href="/doc/formal-reviews/index.html" class="block py-2 px-3 text-slate dark:text-white">Formal Reviews</a>
+          </div>
           <div class="absolute left-0 bottom-10 px-2 pt-6 pb-3 text-sm border-t border-gray-300 dark:border-gray-700 w-full">
             {% if not user.is_authenticated %}
               <a href="{% url 'account_signup' %}" class="block py-2 px-3 text-gray-500 dark:text-gray-400">Join</a>

--- a/templates/includes/_header.html
+++ b/templates/includes/_header.html
@@ -70,7 +70,28 @@
             </span>
             {% endcomment %}
 
-            <a href="/doc/user-guide/intro.html" class="inline link-none"><i class="text-slate fas fa-question-circle dark:text-white/50 dark:hover:text-orange hover:text-orange"></i></a>
+            <span x-data="{ 'guideOpen': false }" class="relative">
+              <i class="inline-block cursor-pointer text-slate fas fa-question-circle dark:text-white/50 dark:hover:text-orange hover:text-orange" @click="guideOpen = !guideOpen"></i>
+
+              <div
+                x-show="guideOpen" x-cloak
+                @click.away="guideOpen = false"
+                x-transition:enter="transition ease-out duration-100"
+                x-transition:enter-start="transform opacity-0 scale-95"
+                x-transition:enter-end="transform opacity-100 scale-100"
+                x-transition:leave="transition ease-in duration-75"
+                x-transition:leave-start="transform opacity-100 scale-100"
+                x-transition:leave-end="transform opacity-0 scale-95"
+                class="absolute right-0 z-10 py-1 px-2 mt-2 w-32 text-left bg-white rounded-md divide-y divide-gray-300 dark:divide-gray-700 ring-1 ring-gray-300 shadow-lg origin-top-right dark:ring-gray-500 dark:bg-charcoal"
+              >
+                <a href="/doc/user-guide/index.html" class="ml-2 block py-2 text-xs cursor-pointer dark:text-white text-charcoal dark:hover:text-orange hover:text-orange">User Guide</a>
+                <a href="/doc/contributor-guide/index.html" class="ml-2 block py-2 text-xs cursor-pointer dark:text-white text-charcoal dark:hover:text-orange hover:text-orange">Contributor Guide</a>
+                <a href="/doc/formal-reviews/index.html" class="ml-2 block py-2 text-xs cursor-pointer dark:text-white text-charcoal dark:hover:text-orange hover:text-orange">Formal Reviews</a>
+
+              </div>
+            </span>
+
+            {# <a href="/doc/user-guide/intro.html" class="inline link-none"><i class="text-slate fas fa-question-circle dark:text-white/50 dark:hover:text-orange hover:text-orange"></i></a> #}
 
             {% if not disable_theme_switcher %}
             {# theme switcher #}

--- a/templates/libraries/category_list.html
+++ b/templates/libraries/category_list.html
@@ -11,7 +11,7 @@
   <div class="py-0 px-0 mt-0 mb-0 w-full md:mb-2 flex flex-row flex-nowrap items-center md:block">
     <div class="flex-auto mb-2 w-full md:block md:w-auto md:mb-0">
       <div>
-          <span class="text-xl md:text-3xl lg:text-4xl">Libraries</span>
+          <span class="text-xl md:text-3xl lg:text-4xl">Libraries by Category</span>
       </div>
     </div>
     <div class="flex-shrink md:hidden">

--- a/templates/libraries/detail.html
+++ b/templates/libraries/detail.html
@@ -53,7 +53,7 @@
 
                 {% if library.cpp_standard_minimum and library.cpp_standard_minimum != 'None' %}{{ library.cpp_standard_minimum }}{% else %}03{% endif %} or Later">
               {% if library.cpp_standard_minimum and library.cpp_standard_minimum != 'None' %}
-                {{ library.cpp_standard_minimum }}{% else %}03{% endif %}+
+                {{ library.cpp_standard_minimum }}{% else %}03{% endif %}
             </span>
             <span class="float-right">{% if object.first_boost_version %}Added in Boost
               {{ object.first_boost_version.display_name }}{% endif %}</span>


### PR DESCRIPTION
resolves #763 
resolves #742 

- removed remaining Slack links
- removed placeholder text from login/sign up forms (still to do on profile update)
- created the docs menu in header as discussed in last meeting
![image](https://github.com/cppalliance/temp-site/assets/49487079/c7956c23-5b6e-4920-a864-27bbde7a1c71)
- likewise added links to all 3 into the mobile menu
- community page updates based on adobe express feedback - this is a step towards getting the page to a much better state, some items are removed at the moment and issues will be created shortly for bringing those back with more content. 
![image](https://github.com/cppalliance/temp-site/assets/49487079/975f6444-c6f5-467e-a93a-6d70ceb05e27)


Lot of style changes in preparation for completing style guide .  Many more to come.

- padding made consistent where it was not before in the panels across homepage, learn, and community
- headers made consistent for panel headers 
- learn page styles toned down and now match the other sections
![image](https://github.com/cppalliance/temp-site/assets/49487079/6e6cebaf-06a2-4b54-9131-6a2740e0b48f)
