### PR TITLE
WIP News UI/UX

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -394,6 +394,11 @@ STATIC_CONTENT_AWS_S3_ENDPOINT_URL = env(
     "STATIC_CONTENT_AWS_S3_ENDPOINT_URL", default="https://s3.us-east-2.amazonaws.com"
 )
 
+# LinkPreview API Key
+LINK_PREVIEW_API_KEY = env(
+    "LINK_PREVIEW_API_KEY", default="changeme"
+)
+
 # JSON configuration of how we map static content in the S3 buckets to URL paths
 STATIC_CONTENT_MAPPING = env(
     "STATIC_CONTENT_MAPPING", default="stage_static_config.json"

--- a/news/forms.py
+++ b/news/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from .helpers import get_link_preview_data
 from .models import BlogPost, Entry, Link, News, Poll, Video
 
 
@@ -29,6 +30,15 @@ class LinkForm(EntryForm):
     class Meta:
         model = Link
         fields = ["title", "publish_at", "external_url", "image"]
+
+    # Holding on this as it's a new feature Issue #437
+    # def save(self, *args, commit=True, **kwargs):
+    #     instance = super().save(*args, commit=False, **kwargs)
+    #     if self.cleaned_data["external_url"] and not self.cleaned_data["image"]:
+    #         link_data = get_link_preview_data(self.cleaned_data["external_url"])
+    #         print(link_data)
+    #     instance.save()
+    #     return instance
 
 
 class NewsForm(EntryForm):

--- a/news/helpers.py
+++ b/news/helpers.py
@@ -1,0 +1,18 @@
+import requests
+
+from django.conf import settings
+
+
+def get_link_preview_data(link):
+    """gets the link preview json response from LinkPreview api"""
+    api_url = "https://api.linkpreview.net"
+    api_key = settings.LINK_PREVIEW_API_KEY
+    target = link
+
+    # TODO: Add additional field `image_size` to help validate image https://docs.linkpreview.net/#image-processing-and-validation
+    response = requests.get(
+        api_url,
+        headers={'X-Linkpreview-Api-Key': api_key},
+        params={'q': target},
+    )
+    return response.json()

--- a/news/templatetags/news_tags.py
+++ b/news/templatetags/news_tags.py
@@ -1,0 +1,9 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def can_edit(context, news_item, *args, **kwargs):
+    request = context.get("request")
+    return news_item.can_edit(request.user)

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1362,6 +1362,11 @@ code,
   margin-right: 0.25rem;
 }
 
+.my-10 {
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
 .mb-4 {
   margin-bottom: 1rem;
 }
@@ -1524,6 +1529,22 @@ code,
 
 .-mt-5 {
   margin-top: -1.25rem;
+}
+
+.ml-3 {
+  margin-left: 0.75rem;
+}
+
+.-mb-3 {
+  margin-bottom: -0.75rem;
+}
+
+.-mb-4 {
+  margin-bottom: -1rem;
+}
+
+.-mb-6 {
+  margin-bottom: -1.5rem;
 }
 
 .block {
@@ -2045,6 +2066,12 @@ code,
   margin-left: calc(1.5rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
 .divide-y > :not([hidden]) ~ :not([hidden]) {
   --tw-divide-y-reverse: 0;
   border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
@@ -2248,6 +2275,16 @@ code,
 .border-white {
   --tw-border-opacity: 1;
   border-color: rgb(255 255 255 / var(--tw-border-opacity));
+}
+
+.border-black {
+  --tw-border-opacity: 1;
+  border-color: rgb(5 26 38 / var(--tw-border-opacity));
+}
+
+.border-gray-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(107 114 128 / var(--tw-border-opacity));
 }
 
 .border-t-white\/5 {
@@ -3140,6 +3177,11 @@ code,
   border-color: rgb(55 65 81 / var(--tw-border-opacity));
 }
 
+.dark .dark\:border-gray-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(107 114 128 / var(--tw-border-opacity));
+}
+
 .dark .dark\:bg-black {
   --tw-bg-opacity: 1;
   background-color: rgb(5 26 38 / var(--tw-bg-opacity));
@@ -3458,6 +3500,14 @@ code,
     margin-left: 1.25rem;
   }
 
+  .md\:mt-4 {
+    margin-top: 1rem;
+  }
+
+  .md\:mt-6 {
+    margin-top: 1.5rem;
+  }
+
   .md\:block {
     display: block;
   }
@@ -3589,6 +3639,12 @@ code,
     --tw-space-x-reverse: 0;
     margin-right: calc(2rem * var(--tw-space-x-reverse));
     margin-left: calc(2rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(4rem * var(--tw-space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .md\:divide-x > :not([hidden]) ~ :not([hidden]) {
@@ -3781,6 +3837,11 @@ code,
   .md\:text-2xl {
     font-size: 1.5rem;
     line-height: 2rem;
+  }
+
+  .md\:text-sm {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
   }
 }
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1510,10 +1510,6 @@ code,
   margin-left: 1rem;
 }
 
-.-ml-1 {
-  margin-left: -0.25rem;
-}
-
 .block {
   display: block;
 }
@@ -3618,12 +3614,12 @@ code,
     border-left-width: 0px;
   }
 
-  .md\:border-b-0 {
-    border-bottom-width: 0px;
-  }
-
   .md\:border-l-2 {
     border-left-width: 2px;
+  }
+
+  .md\:border-b-0 {
+    border-bottom-width: 0px;
   }
 
   .md\:border-orange {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1510,6 +1510,22 @@ code,
   margin-left: 1rem;
 }
 
+.-mt-3 {
+  margin-top: -0.75rem;
+}
+
+.-mt-4 {
+  margin-top: -1rem;
+}
+
+.-mr-3 {
+  margin-right: -0.75rem;
+}
+
+.-mt-5 {
+  margin-top: -1.25rem;
+}
+
 .block {
   display: block;
 }
@@ -3555,6 +3571,12 @@ code,
     --tw-space-x-reverse: 0;
     margin-right: calc(1.5rem * var(--tw-space-x-reverse));
     margin-left: calc(1.5rem * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:space-x-11 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(2.75rem * var(--tw-space-x-reverse));
+    margin-left: calc(2.75rem * calc(1 - var(--tw-space-x-reverse)));
   }
 
   .md\:space-x-3 > :not([hidden]) ~ :not([hidden]) {

--- a/templates/includes/_header.html
+++ b/templates/includes/_header.html
@@ -171,7 +171,7 @@
                 <a href="{% url 'account_signup' %}" class="hover:no-underline inline font-medium dark:text-white dark:visited:text-white text-slate visited:text-slate dark:hover:text-orange hover:text-orange">Join</a>
               {% else %}
                 {% if user.image %}
-                  <span class="inline-block h-[30px] w-[30px] overflow-hidden rounded mt-1">
+                  <span class="inline-block h-[30px] w-[30px] overflow-hidden rounded mt-1 border border-gray-400 dark:border-gray-500">
                   <img src="{{ user.image.url }}" alt="user" class="h-full w-full cursor-pointer object-cover" @click="userOpen = !userOpen" />
                   </span>
                 {% else %}

--- a/templates/news/_entry_form.html
+++ b/templates/news/_entry_form.html
@@ -13,7 +13,7 @@
 
   <div class="mt-4 text-right">
     {% if cancel_url %}
-    <a class="py-2 px-3 text-sm text-black rounded" href="{{ cancel_url }}">
+    <a class="py-2 px-3 text-sm text-black dark:text-white rounded" href="{{ cancel_url }}">
       Cancel
     </a>
     {% endif %}

--- a/templates/news/detail.html
+++ b/templates/news/detail.html
@@ -8,10 +8,7 @@
 
   <!-- end breadcrumb -->
   <div class="py-0 px-3 mb-3 md:py-6 md:px-0">
-    <div class="py-16 md:mx-auto md:w-3/4">
-      <h1 class="text-4xl">{{ entry.title }}</h1>
-      <p class="mt-0 text-sm font-light">{{ entry.publish_at|date:"M jS, Y" }}</p>
-
+    <div class="py-8 md:mx-auto md:w-3/4">
       <!-- Author or Moderator Actions -->
       <div class="space-x-3 text-right">
         {% if not entry.is_approved %}
@@ -31,42 +28,60 @@
           {% endif %}
         </div>
         {% endif %}
-        {% if user_can_edit %}
-          <a href="{% url 'news-update' entry.slug %}" class="inline-block items-center dark:text-white">
-            <i class="fas fa-edit"></i>
+        {% if user_can_delete %}
+          <a href="{% url 'news-delete' entry.slug %}" class="float-right inline-block items-center dark:text-white/50 dark:hover:text-orange text-sm ml-3">
+            <i class="fas fa-trash-alt"></i>
           </a>
         {% endif %}
-        {% if user_can_delete %}
-          <a href="{% url 'news-delete' entry.slug %}" class="inline-block items-center dark:text-white">
-            <i class="fas fa-trash-alt"></i>
+        {% if user_can_edit %}
+          <a href="{% url 'news-update' entry.slug %}" class="float-right inline-block items-center dark:text-white/50 dark:hover:text-orange text-sm ml-3">
+            <i class="fas fa-edit"></i>
           </a>
         {% endif %}
       </div>
       <!-- End Actions -->
+      <h1 class="text-4xl">{{ entry.title }}</h1>
+      <p class="mt-0 py-0 text-xs">{{ entry.publish_at|date:"M jS, Y" }}</p>
+      <div class="space-x-2 mt-3 flex items-center">
+        {% if entry.author.image %}
+          <span class="inline-block h-[30px] w-[30px] overflow-hidden rounded border border-gray-400 dark:border-gray-500">
+            <img src="{{ entry.author.image.url }}" alt="{{ entry.author.get_full_name }}" class="h-full w-full object-cover" />
+          </span>
+        {% else %}
+          <span class="inline-block h-[30px] w-[30px] bg-white rounded dark:text-white dark:bg-slate border border-gray-400 dark:border-gray-500">
+            <i class="text-2xl fas fa-user ml-1" title="{{ entry.author.get_full_name }}"></i>
+          </span>
+        {% endif %}
+        {% if entry.author.get_full_name %}
+          <span class="inline-block">{{ entry.author.get_full_name }}</span>
+        {% endif %}
+      </div>
 
-      {% if entry.external_url %}
-      <p>{{ entry.external_url|escape|urlize }}</p>
-      {% endif %}
+      <div class="block px-6 py-4 my-6 w-full bg-white rounded-lg dark:bg-charcoal">
+        {% if entry.external_url %}
+        <p>{{ entry.external_url|escape|urlize }}</p>
+        {% endif %}
 
-      {% if entry.image %}
-      <img src="{{ entry.image.url }}" class="mb-5 w-full h-auto md:float-left md:mr-5 md:w-1/6 md:min-w-[200px]">
-      {% endif %}
-      {{ entry.content|linebreaks }}
+        {% if entry.image %}
+        <img src="{{ entry.image.url }}" class="mb-2 w-full h-auto md:float-right md:ml-5 md:mt-6 md:w-1/6 md:min-w-[200px] border border-black">
+        {% endif %}
+        {{ entry.content|linebreaks }}
+      </div>
 
     </div>
 
     {% if next or prev %}
-    <div class="flex my-16 md:mx-auto md:w-3/4">
-      {% if next %}
+    <div class="flex my-4 md:mx-auto md:w-3/4">
       <div class="w-1/2 text-left">
-        <a href="{{ next.get_absolute_url }}" class="py-2 px-3 text-sm font-medium uppercase bg-gray-300 rounded-md border border-slate">Newer Entries</a>
-      </div>
+      {% if next %}
+        <a href="{{ next.get_absolute_url }}" class="py-1 px-2 text-xs text-white rounded-md border md:text-sm border-orange bg-orange hover:bg-orange/75 dark:bg-charcoal dark:hover:bg-charcoal/75">Newer Entries</a>
       {% endif  %}
-      {% if prev %}
-      <div class="w-1/2 text-right">
-        <a href="{{ prev.get_absolute_url }}" class="py-2 px-3 text-sm font-medium uppercase bg-gray-300 rounded-md border border-slate">Older Entries</a>
       </div>
+      <div class="w-1/2 text-right">
+      {% if prev %}
+        <a href="{{ prev.get_absolute_url }}" class="py-1 px-2 text-xs text-white rounded-md border md:text-sm border-orange bg-orange hover:bg-orange/75 dark:bg-charcoal dark:hover:bg-charcoal/75">Older Entries</a>
       {% endif %}
+      </div>
     </div>
     {% endif %}
 

--- a/templates/news/list.html
+++ b/templates/news/list.html
@@ -1,81 +1,79 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
+{% load news_tags %}
 
 {% block title %}{% trans "News" %}{% endblock %}
 
 {% block content %}
-  <div class="py-0 px-3 mb-3 md:py-6 md:px-0">
+  <div class="py-0 px-3 md:px-0 mt-0 mb-0 w-full md:mb-2">
     <div class="md:w-full">
-      <h1 class="text-4xl text-center">Latest Stories</h1>
+      <h1 class="text-4xl">Latest Stories</h1>
 
-      <div class="mx-auto w-auto sm:w-[550px]">
-      <p class="mt-0 text-justify">
-        Stay up to date with Boost and the C++ ecosystem with the latest news, videos, resources, polls, and user-created content.
-        {% if user.is_authenticated %}
-        Or, <a href="{% url 'news-create' %}" class="whitespace-nowrap text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">Create a Post</a> to include in the feed (posts are reviewed before publication).
-        {% else %}
-        Signed-in users may submit items to include in the feed (posts are reviewed before publication).
-        {% endif %}
-      </p>
-    </div>
-
-
-
-
-
-      <!-- General filters, by news type -->
-      <div class="mx-auto w-full sm:w-fit">
-        <div class="grid grid-cols-3 justify-center place-items-center space-y-1 space-x-1 sm:grid-cols-6 sm:space-y-0">
-
-          {% url 'news' as target_url %}
-          <a href="{{ target_url }}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
-            <h6 class="pb-1 text-base">All</h6>
-            <i class="fa fa-globe"></i>
-          </a>
-
-          {% url 'news-news-list' as target_url %}
-          <a href="{{ target_url }}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
-            <h6 class="pb-1 text-base">News</h6>
-            <i class="fa fa-newspaper"></i>
-          </a>
-
-          {% url 'news-blogpost-list' as target_url %}
-          <a href="{{ target_url }}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
-            <h6 class="pb-1 text-base">Blogs</h6>
-            <i class="fa fa-comment"></i>
-          </a>
-
-          {% url 'news-link-list' as target_url %}
-          <a href="{{ target_url }}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
-            <h6 class="pb-1 text-base">Links</h6>
-            <i class="fas fa-link"></i>
-          </a>
-
-          {% comment %}
-          <!-- turning off polls for now -->
-          {% url 'news-poll-list' as target_url %}
-          <a href="{{ target_url }}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
-            <h6 class="pb-1 text-base">Polls</h6>
-            <i class="fa fa-poll"></i>
-          </a>
-          {% endcomment %}
-
-          {% url 'news-video-list' as target_url %}
-          <a href="{{ target_url }}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
-            <h6 class="pb-1 text-base">Videos</h6>
-            <i class="fa fa-video"></i>
-          </a>
-
-          {% if is_moderator %}
-          <a href="{% url "news-moderate" %}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
-            <h6 class="pb-1 text-base">Moderate</h6>
-            <i class="fa fa-thumbs-up"></i>
-          </a>
-          {% endif %}
+      <div class="md:flex md:space-x-11">
+        <div class="md:w-1/2 w-full">
+          <p class="mt-0 text-justify">
+            Stay up to date with Boost and the C++ ecosystem with the latest news, videos, resources, polls, and user-created content.
+            {% if user.is_authenticated %}
+            Or, <a href="{% url 'news-create' %}" class="whitespace-nowrap text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">Create a Post</a> to include in the feed (posts are reviewed before publication).
+            {% else %}
+            Signed-in users may submit items to include in the feed (posts are reviewed before publication).
+            {% endif %}
+          </p>
         </div>
 
-      </div>
+        <!-- General filters, by news type -->
+        <div class="md:w-1/2 w-full pt-6">
+          <div class="grid grid-cols-3 justify-center place-items-center space-y-1 space-x-1 sm:grid-cols-6 sm:space-y-0">
+
+            {% url 'news' as target_url %}
+            <a href="{{ target_url }}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
+              <h6 class="pb-1 text-base">All</h6>
+              <i class="fa fa-globe"></i>
+            </a>
+
+            {% url 'news-news-list' as target_url %}
+            <a href="{{ target_url }}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
+              <h6 class="pb-1 text-base">News</h6>
+              <i class="fa fa-newspaper"></i>
+            </a>
+
+            {% url 'news-blogpost-list' as target_url %}
+            <a href="{{ target_url }}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
+              <h6 class="pb-1 text-base">Blogs</h6>
+              <i class="fa fa-comment"></i>
+            </a>
+
+            {% url 'news-link-list' as target_url %}
+            <a href="{{ target_url }}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
+              <h6 class="pb-1 text-base">Links</h6>
+              <i class="fas fa-link"></i>
+            </a>
+
+            {% comment %}
+            <!-- turning off polls for now -->
+            {% url 'news-poll-list' as target_url %}
+            <a href="{{ target_url }}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
+              <h6 class="pb-1 text-base">Polls</h6>
+              <i class="fa fa-poll"></i>
+            </a>
+            {% endcomment %}
+
+            {% url 'news-video-list' as target_url %}
+            <a href="{{ target_url }}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
+              <h6 class="pb-1 text-base">Videos</h6>
+              <i class="fa fa-video"></i>
+            </a>
+
+            {% if is_moderator %}
+            <a href="{% url "news-moderate" %}" class="w-20 p-1 text-center rounded-lg cursor-pointer hover:bg-gray-100 group dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange{% if request.path == target_url %} bg-gray-100 dark:bg-slate text-orange dark:text-orange{% endif %}">
+              <h6 class="pb-1 text-base">Moderate</h6>
+              <i class="fa fa-thumbs-up"></i>
+            </a>
+            {% endif %}
+          </div>
+        </div>
+    </div>
 
     <div class="my-5">
       <div class="mx-auto w-full">
@@ -126,6 +124,12 @@
             {% endif %}
           </div>
           <div class="block p-6 mb-10 w-full bg-white rounded-lg md:ml-6 dark:bg-charcoal">
+            {% can_edit news_item=entry as editable %}
+            {% if editable %}
+              <a href="{% url 'news-update' entry.slug %}" class="float-right dark:text-white/50 hover:text-orange dark:hover:text-orange -mt-5 -mr-3 text-sm">
+                <i class="fas fa-edit"></i>
+              </a>
+            {% endif %}
             <h2 class="py-0 my-0 text-xl font-semibold"><a class="text-orange hover:text-info-600 focus:text-info-600 active:text-info-700" {% if entry.tag == "link" %}target="_blank"{% endif %} href="{% if entry.tag == "link" %}{{ entry.external_url }}{% else %}{{ entry.get_absolute_url }}{% endif %}">
               {{ entry.title }}
             </a></h2>

--- a/templates/news/list.html
+++ b/templates/news/list.html
@@ -10,7 +10,7 @@
     <div class="md:w-full">
       <h1 class="text-4xl">Latest Stories</h1>
 
-      <div class="md:flex md:space-x-11">
+      <div class="md:flex md:space-x-16">
         <div class="md:w-1/2 w-full">
           <p class="mt-0 text-justify">
             Stay up to date with Boost and the C++ ecosystem with the latest news, videos, resources, polls, and user-created content.
@@ -114,11 +114,11 @@
           </div>
           <div class="hidden pt-2 mt-4 text-xs text-left md:block w-[70px]">
             {% if entry.author.image %}
-              <span class="inline-block h-[30px] w-[30px] overflow-hidden rounded">
+              <span class="inline-block h-[30px] w-[30px] overflow-hidden rounded border border-gray-400 dark:border-gray-500">
                 <img src="{{ entry.author.image.url }}" alt="{{ entry.author.get_full_name }}" class="h-full w-full object-cover" />
               </span>
             {% else %}
-              <span class="inline-block h-[30px] w-[30px] bg-white rounded dark:text-white dark:bg-slate">
+              <span class="inline-block h-[30px] w-[30px] bg-white rounded dark:text-white dark:bg-slate border border-gray-400 dark:border-gray-500">
                 <i class="text-2xl fas fa-user ml-1" title="{{ entry.author.get_full_name }}"></i>
               </span>
             {% endif %}
@@ -177,11 +177,11 @@
               </div>
               <div class="pt-2 mt-4 w-1/3 text-xs text-right">
                 {% if entry.author.image %}
-                  <span class="inline-block h-[30px] w-[30px] overflow-hidden rounded">
+                  <span class="inline-block h-[30px] w-[30px] overflow-hidden rounded border border-gray-400 dark:border-gray-500">
                     <img src="{{ entry.author.image.url }}" alt="{{ entry.author.get_full_name }}" class="h-full w-full object-cover" />
                   </span>
                 {% else %}
-                  <span class="inline-block h-[30px] w-[30px] bg-white rounded dark:text-white dark:bg-slate">
+                  <span class="inline-block h-[30px] w-[30px] bg-white rounded dark:text-white dark:bg-slate border border-gray-400 dark:border-gray-500">
                     <i class="text-2xl fas fa-user mr-1" title="{{ entry.author.get_full_name }}"></i>
                   </span>
                 {% endif %}


### PR DESCRIPTION
🚧 stubs out linkpreview service
Holding on this until after news is cleaned up

🚧 cleaning up news list
* Added templatetag for can edit conditional
* Adding edit icons
* Rearranged top text area so title matches alignment of other sections of the site.

🚧 cleans up post detail view
* Styles edit and delete icons to right
* Adds block behind post content to match other areas of site
* Adds author avatar and name
* Adds borders to all avatars on news and header
* Cleans up news pagination buttons adn fixes bugs
