### PR TITLE
Adds ability to get library-versions for `master` and `develop` branches via the admin 

### DIFF
--- a/templates/libraries/includes/version_alert.html
+++ b/templates/libraries/includes/version_alert.html
@@ -4,8 +4,10 @@
             <i class="fas fa-exclamation-circle"></i>
             {% if version.beta %}
             This is a beta version of Boost.
-            {% else %}
+            {% elif version.full_release %}
             This is an older version and was released in {{ version.release_date|date:"Y"}}.
+            {% else %}
+            This version of Boost is under active development.
             {% endif %}
            The current version is
             {% if latest_library_version %}

--- a/versions/admin.py
+++ b/versions/admin.py
@@ -4,7 +4,11 @@ from django.http import HttpResponseRedirect
 from django.urls import path
 
 from . import models
-from .tasks import import_versions, import_most_recent_beta_release
+from .tasks import (
+    import_versions,
+    import_most_recent_beta_release,
+    import_development_versions,
+)
 
 
 class VersionFileInline(admin.StackedInline):
@@ -35,6 +39,8 @@ class VersionAdmin(admin.ModelAdmin):
     def import_new_releases(self, request):
         import_versions(new_versions_only=True)
         import_most_recent_beta_release(delete_old=True)
+        # Import the master and develop branches
+        import_development_versions.delay()
         self.message_user(
             request,
             """


### PR DESCRIPTION
Part of #386. 

- Adjusts the github call to get the gitmodules file to be more flexible and retrieve for tags and branches 
- Adds import of development versions to the admin button that imports new version data 
- Adjusts the outdated version notice to accommodate development branches 

![Screenshot 2023-11-15 at 9 28 19 AM](https://github.com/cppalliance/temp-site/assets/2286304/5c6f1087-76a3-42e8-b347-416ce603faad)

