### PR TITLE
Require profile photo before users can post news

### DIFF
--- a/news/tests/fixtures.py
+++ b/news/tests/fixtures.py
@@ -96,12 +96,18 @@ def make_user(db):
 def moderator_user(db, make_user):
     # we could use `tp.make_user` but we need this fix to be released
     # https://github.com/revsys/django-test-plus/issues/199
-    return make_user(email="moderator@example.com", perms=["news.*"])
+    user = make_user(email="moderator@example.com", perms=["news.*"])
+    user.image = "test.png"
+    user.save()
+    return user
 
 
 @pytest.fixture
 def regular_user(db, make_user):
-    return make_user(email="regular@example.com")
+    user = make_user(email="regular@example.com")
+    user.image = "test.png"
+    user.save()
+    return user
 
 
 @pytest.fixture

--- a/news/tests/test_views.py
+++ b/news/tests/test_views.py
@@ -347,6 +347,25 @@ def test_news_create_multiplexer(tp, user_type, request):
         assert model_class.__name__ == item["model_name"]
 
 
+def test_news_create_require_profile_photo(tp, user):
+    """Users must have a profile photo before they can post news."""
+    url_name = "news-create"
+    url = tp.reverse(url_name)
+
+    # Test with the image
+    with tp.login(user):
+        response = tp.get(url)
+        tp.response_200(response)
+
+    # Delete the user's image and confirm they can access the page
+    user.image.delete()
+    user.refresh_from_db()
+    with tp.login(user):
+        response = tp.get(url)
+        tp.response_302(response)
+        assert response.url == tp.reverse("profile-account")
+
+
 @pytest.mark.parametrize(
     "method", ["DELETE", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
 )

--- a/news/views.py
+++ b/news/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.humanize.templatetags import humanize
 from django.contrib.messages.views import SuccessMessageMixin
 from django.http import Http404, HttpResponseRedirect
+from django.shortcuts import redirect
 from django.template.defaultfilters import date as datefilter
 from django.urls import reverse_lazy
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -219,6 +220,13 @@ class AllTypesCreateView(LoginRequiredMixin, TemplateView):
             "add_label": view.add_label,
             "add_url_name": view.add_url_name,
         }
+
+    def dispatch(self, request, *args, **kwargs):
+        """User must have a profile photo to post an entry."""
+        if request.user.is_authenticated and not request.user.image:
+            messages.warning(request, "Please add a profile photo first.")
+            return redirect("profile-account")
+        return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Closes #793 

- Adds check that user has a profile photo before letting them access the page where they can choose news to post
- If they fail the check, show a message and redirect to the profile screen. 

Example of result: 


https://github.com/cppalliance/temp-site/assets/2286304/17d8a23a-fa98-461f-ab72-7ff8f9d7d081
