### PR TITLE
K8S Gateway API replaces Ingress

### DIFF
--- a/kube/boost/templates/gateway.yaml
+++ b/kube/boost/templates/gateway.yaml
@@ -1,0 +1,77 @@
+# vim: ft=sls nolist
+
+{{- if eq .Values.gatewayType "gce" }}
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: www-boost-{{.Values.deploymentEnvironment}}
+  annotations:
+    networking.gke.io/certmap: {{ .Values.certmap }}
+spec:
+  gatewayClassName: gke-l7-global-external-managed
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+    - name: http
+      protocol: HTTP
+      port: 80
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: www-boost-{{.Values.deploymentEnvironment}}
+spec:
+  parentRefs:
+    - kind: Gateway
+      name: www-boost-{{.Values.deploymentEnvironment}}
+      sectionName: https
+  hostnames:
+    - www.{{.Values.publicFqdn}}
+    - {{.Values.publicFqdn}}
+    - www.{{.Values.publicFqdn2}}
+    - {{.Values.publicFqdn2}}
+    - www.{{.Values.publicFqdn3}}
+    - {{.Values.publicFqdn3}}
+  rules:
+    - matches:
+      - path:
+          value: /
+      backendRefs:
+      - name: boost
+        port: 80
+{{ end }}
+
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: www-boost-{{.Values.deploymentEnvironment}}
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        port: 80
+        requestPath: /lbcheck
+  targetRef:
+    group: ""
+    kind: Service
+    name: boost
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: redirect
+spec:
+  parentRefs:
+    - kind: Gateway
+      name: www-boost-{{.Values.deploymentEnvironment}}
+      sectionName: http
+  rules:
+  - filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -66,9 +66,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "cppal-dev.boost.cppalliance.org, www.cppal-dev.boost.cppalliance.org, boost.org, www.boost.org, cppal-dev2.boost.cppalliance.org, www.cppal-dev2.boost.cppalliance.org"
+    value: "*.boost.org, *.boost.cppalliance.org, cppal-dev.boost.cppalliance.org, www.cppal-dev.boost.cppalliance.org, boost.org, www.boost.org, cppal-dev2.boost.cppalliance.org, www.cppal-dev2.boost.cppalliance.org"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://0.0.0.0, http://localhost, https://cppal-dev.boost.cppalliance.org, https://www.cppal-dev.boost.cppalliance.org, https://boost.org, https://www.boost.org, https://cppal-dev2.boost.cppalliance.org, https://www.cppal-dev2.boost.cppalliance.org"
+    value: "http://*.boost.cppalliance.org, https://*.boost.cppalliance.org, http://0.0.0.0, http://localhost, https://cppal-dev.boost.cppalliance.org, https://www.cppal-dev.boost.cppalliance.org, https://boost.org, https://www.boost.org, https://cppal-dev2.boost.cppalliance.org, https://www.cppal-dev2.boost.cppalliance.org"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS
@@ -225,7 +225,9 @@ hostAliases:
     hostnames:
       - "mailman-cppal-dev.boost.cppalliance.org"
 
-ingressType: gce
+ingressType: "none"
+gatewayType: "gce"
+certmap: "cppal-dev-certmap"
 managedCertName: managed-cert-cppal-dev,managed-cert-cppal-dev2
 secretCertName: boostorgcert
 ingressStaticIp: cppal-dev-ingress1

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -225,7 +225,9 @@ hostAliases:
     hostnames:
       - "mailman-cppal-dev.boost.cppalliance.org"
 
-ingressType: gce
+ingressType: "gce"
+gatewayType: "none"
+certmap: "production-certmap"
 managedCertName: managed-cert-boost-production,managed-cert-boost-production2
 secretCertName: boostorgcert
 ingressStaticIp: boost-production-ingress1

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -225,7 +225,9 @@ hostAliases:
     hostnames:
       - "mailman-cppal-dev.boost.cppalliance.org"
 
-ingressType: gce
+ingressType: "none"
+gatewayType: "gce"
+certmap: "stage-certmap"
 managedCertName: managed-cert-boost-stage,managed-cert-boost-stage2
 secretCertName: boostorgcert
 ingressStaticIp: boost-stage-ingress1

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -201,6 +201,8 @@ NginxVolumeMounts:
 
 hostAliases: {}
 
-ingressType: nginx
+ingressType: "nginx"
+gatewayType: "none"
+certmap: "revsys-certmap"
 redisInstall: false
 celeryInstall: false


### PR DESCRIPTION
The next generation Ingress is 'Gateway API'.  
It's necessary to switch to Gateway because that is compatible with Certificate Manager in GCP, which in turn is needed to allow 'DNS authorization' type certificates.
