### PR TITLE
Download release notes HTML for past releases 

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+from .models import RenderedContent
+
+
+@admin.register(RenderedContent)
+class RenderedContentAdmin(admin.ModelAdmin):
+    list_display = ("cache_key", "content_type")
+    search_fields = ("cache_key",)

--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -131,6 +131,14 @@
         </div>
       </div>
     </section>
+
+    {% if release_notes %}
+      <section id="libraryReadMe"
+        class="p-6 my-4 bg-white rounded-lg shadow-lg dark:text-white text-slate dark:bg-charcoal dark:bg-neutral-700">
+        {{ release_notes|safe }}
+      </section>
+    {% endif %}
+
   {% endif %}
   </main>
 {% endblock %}

--- a/versions/models.py
+++ b/versions/models.py
@@ -93,6 +93,12 @@ class Version(models.Model):
         cleaned = re.sub(r"^[^0-9]*", "", self.name).split("beta")[0]
         return [part for part in cleaned.split(".") if part]
 
+    @cached_property
+    def release_notes_cache_key(self):
+        """Returns the cahe key used to access the release notes in the
+        RenderedContent model."""
+        return f"release_notes_{self.slug}"
+
 
 class VersionFile(models.Model):
     Unix = "Unix"

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -6,10 +6,12 @@ from django.conf import settings
 from django.core.management import call_command
 from fastcore.xtras import obj2dict
 from core.githubhelper import GithubAPIClient, GithubDataParser
+from core.models import RenderedContent
 from libraries.github import LibraryUpdater
 from libraries.models import Library, LibraryVersion
 from libraries.tasks import get_and_store_library_version_documentation_urls_for_version
 from versions.models import Version
+from versions.releases import store_release_notes_for_version
 
 
 logger = structlog.getLogger(__name__)
@@ -48,6 +50,24 @@ def import_versions(delete_versions=False, new_versions_only=False, token=None):
 
         logger.info("import_versions_importing_version", version_name=name)
         import_version.delay(name, tag=tag, token=token)
+
+    # Get all release notes
+    import_release_notes(new_versions_only=new_versions_only)
+
+
+@app.task
+def import_release_notes(new_versions_only):
+    """Imports release notes from the existing rendered
+    release notes in the repository."""
+    for version in Version.objects.active().filter(full_release=True):
+        if (
+            new_versions_only
+            and RenderedContent.objects.filter(
+                cache_key=version.release_notes_cache_key
+            ).exists()
+        ):
+            continue
+        store_release_notes_for_version(version.pk)
 
 
 @app.task

--- a/versions/tests/test_models.py
+++ b/versions/tests/test_models.py
@@ -70,5 +70,11 @@ def test_cleaned_version_parts(name, expected_cleaned_parts, version):
     assert version.cleaned_version_parts == expected_cleaned_parts
 
 
+def test_release_notes_cache_key(version):
+    """Test the release_notes_cache_key property method"""
+    expected = f"release_notes_{version.slug}"
+    assert version.release_notes_cache_key == expected
+
+
 def test_version_file_creation(full_version_one):
     assert full_version_one.downloads.count() == 3

--- a/versions/views.py
+++ b/versions/views.py
@@ -7,6 +7,7 @@ from django.contrib import messages
 from itertools import groupby
 from operator import attrgetter
 
+from core.models import RenderedContent
 from libraries.forms import VersionSelectionForm
 from versions.models import Version
 
@@ -51,8 +52,18 @@ class VersionDetail(FormMixin, DetailView):
         context["is_current_release"] = is_current_release
 
         context["heading"] = self.get_version_heading(obj, is_current_release)
+        context["release_notes"] = self.get_release_notes(obj)
 
         return context
+
+    def get_release_notes(self, obj):
+        try:
+            rendered_content = RenderedContent.objects.get(
+                cache_key=obj.release_notes_cache_key
+            )
+            return rendered_content.content_html
+        except RenderedContent.DoesNotExist:
+            return
 
     def get_version_heading(self, obj, is_current_release):
         """Returns the heading of the versions template"""


### PR DESCRIPTION
Part of #617 

- Adds admin for `RenderedContent` model 
- Adds release notes to the release notes detail page view and template 
- Adds a property to the version model with the release notes cache key, to make it easier to get the release notes for that version 
- Adds functions to get the release notes html from the repo, do some basic stripping of it, and saving it to the RenderedContent model 
- Hooks those functions up to a celery task, and add that celery task to the admin button that downloads new versions 

In a future PR: 

- More HTML massaging to remove some of the duplicated markup 

To use this feature: 

- Click the "import new releases" button again, but be aware that the output isn't yet pretty, so I wouldn't recommend it yet 

<img width="1920" alt="Screenshot 2023-11-22 at 2 13 00 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/fb28ce45-ff71-472f-989c-95d54406ea07">
<img width="1915" alt="Screenshot 2023-11-22 at 2 12 45 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/0898a8ce-74cf-4cdd-9772-a0526e8cbc09">
<img width="541" alt="Screenshot 2023-11-22 at 2 12 38 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/05cad4b3-ca0c-4f5a-ad26-2e679e6ffc38">
