### PR TITLE
Make current-boost-version dynamic for boost-gecko in site header

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -132,6 +132,8 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                # Our stuff (see core.context_processors.py)
+                "core.context_processors.current_release",
             ],
             "loaders": [
                 "django.template.loaders.filesystem.Loader",

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,0 +1,7 @@
+from versions.models import Version
+
+
+def current_release(request):
+    """Custom context processor that adds the current release to the context"""
+    current_release = Version.objects.most_recent()
+    return {"current_release": current_release}

--- a/core/tests/test_context_processors.py
+++ b/core/tests/test_context_processors.py
@@ -1,0 +1,12 @@
+from core.context_processors import current_release
+
+
+def test_current_release_context(
+    version, beta_version, inactive_version, old_version, rf
+):
+    """Test the current_release context processor. Making the other versions
+    ensures that the most_recent() method returns the correct version."""
+    request = rf.get("/")
+    context = current_release(request)
+    assert "current_release" in context
+    assert context["current_release"] == version

--- a/news/tests/test_views.py
+++ b/news/tests/test_views.py
@@ -106,8 +106,10 @@ def test_entry_list(
     if authenticated:
         tp.login(regular_user)
 
-    # 8 queries if authenticated, less otherwise
-    response = tp.assertGoodView(tp.reverse(url_name), test_query_count=9, verbose=True)
+    # 10 queries if authenticated, less otherwise
+    response = tp.assertGoodView(
+        tp.reverse(url_name), test_query_count=10, verbose=True
+    )
 
     expected = [today_news, yesterday_news]
     assert list(response.context.get("entry_list", [])) == expected
@@ -139,7 +141,7 @@ def test_entry_list_queries(tp, make_entry):
     ]
 
     # 4 queries
-    response = tp.assertGoodView(tp.reverse("news"), test_query_count=28, verbose=True)
+    response = tp.assertGoodView(tp.reverse("news"), test_query_count=29, verbose=True)
 
     entry_list = response.context.get("entry_list", [])
     assert set(e.id for e in entry_list) == set(e.id for e in expected)
@@ -331,7 +333,7 @@ def test_news_create_multiplexer(tp, user_type, request):
 
     user = request.getfixturevalue(user_type)
     with tp.login(user):
-        tp.assertGoodView(url, test_query_count=4, verbose=True)
+        tp.assertGoodView(url, test_query_count=5, verbose=True)
 
     expected = [BlogPostForm, LinkForm, NewsForm, VideoForm]
     if "moderator" in user_type:
@@ -396,7 +398,7 @@ def test_news_create_get(tp, regular_user, url_name, form_class):
         # assertGoodView expects a resolved URL
         # see https://github.com/revsys/django-test-plus/issues/202
         url = tp.reverse(url_name)
-        tp.assertGoodView(url, test_query_count=3, verbose=True)
+        tp.assertGoodView(url, test_query_count=4, verbose=True)
 
     form = tp.get_context("form")
     assert isinstance(form, form_class)
@@ -676,7 +678,7 @@ def test_news_moderation_filter_unapproved_news(tp, make_entry, moderator_user):
         # SELECT "django_content_type"... (perms)
         # SELECT "django_content_type"... (perms and groups, may need debugging)
         # SELECT "news_entry"...
-        response = tp.assertGoodView(url, test_query_count=6, verbose=True)
+        response = tp.assertGoodView(url, test_query_count=7, verbose=True)
 
     content = str(response.content)
     for e in unapproved_published + unapproved_unpublished:

--- a/templates/includes/_header.html
+++ b/templates/includes/_header.html
@@ -29,7 +29,9 @@
           </nav>
           <nav class="flex items-center space-x-3 lg:space-x-5 h-[30px]" x-data="{ 'searchOpen': false }">
             <span class="relative">
-              <i id="gecko-search-button" data-current-boost-version="1_83_0" data-theme-mode="light" data-font-family="Cairo, sans-serif" class="inline -mt-1 cursor-pointer text-slate fas fa-search dark:text-white/50 dark:hover:text-orange hover:text-orange"></i>
+              {% if current_release %}
+              <i id="gecko-search-button" data-current-boost-version="{{ current_release.stripped_boost_url_slug }}" data-theme-mode="light" data-font-family="Cairo, sans-serif" class="inline -mt-1 cursor-pointer text-slate fas fa-search dark:text-white/50 dark:hover:text-orange hover:text-orange"></i>
+              {% endif %}
               <script>
                 const geckoSearchButton = document.getElementById('gecko-search-button');
                 geckoSearchButton.setAttribute('data-theme-mode', localStorage.getItem('colorMode') === 'dark' ? 'dark' : 'light');

--- a/versions/models.py
+++ b/versions/models.py
@@ -66,6 +66,16 @@ class Version(models.Model):
         return self.slug.replace("-", "_").replace(".", "_")
 
     @cached_property
+    def stripped_boost_url_slug(self):
+        """Return the only the numbers and underscores for this version
+
+        Example:
+        - "boost-1.75.0" --> "1_75_0"
+        - "develop" --> "develop"
+        """
+        return self.slug.replace("-", "_").replace(".", "_").replace("boost_", "")
+
+    @cached_property
     def boost_release_notes_url(self):
         """Return the URL path to the release notes for this version of Boost on
         the existing Boost.org website.

--- a/versions/tests/test_models.py
+++ b/versions/tests/test_models.py
@@ -78,3 +78,18 @@ def test_release_notes_cache_key(version):
 
 def test_version_file_creation(full_version_one):
     assert full_version_one.downloads.count() == 3
+
+
+@pytest.mark.parametrize(
+    "slug, expected",
+    [
+        ("boost-1.75.0", "1_75_0"),
+        ("develop", "develop"),
+        ("boost_2.0.1", "2_0_1"),
+    ],
+)
+def test_stripped_boost_url_slug(slug, expected, version):
+    version.slug = slug
+    version.save()
+    version.refresh_from_db()
+    assert version.stripped_boost_url_slug == expected


### PR DESCRIPTION
Closes #844 

- Adds a context processor to add the current release to the context on all pages 
- Adds a `cached_property` to the `Version` model that formats the slug the way we need it 
- Makes the inclusion of the data conditional on having a most recent release, so the site doesn't have a problem if data hasn't been imported
- Fix some tests

Local demo: 

<img width="617" alt="Screenshot 2023-11-30 at 1 26 29 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/9981649e-6fc7-49de-a8af-0ac20035c0c4">
