### PR TITLE
Margin-left on news listing

### DIFF
--- a/templates/news/list.html
+++ b/templates/news/list.html
@@ -139,7 +139,7 @@
                 </a>
               </h2>
             </div>
-              <div class="md:block text-xs hidden ml-auto">
+              <div class="md:block text-xs hidden ml-auto" style="margin-left: auto;">
                 {{ entry.author.get_full_name }}<br />
                 <span class="text-xs">{{ entry.publish_at|date:"M jS, Y" }}</span>
               </div>


### PR DESCRIPTION
None of the CSS seems to be getting picked up on the news listing page, testing with a small change.


