### PR TITLE
Mark special chars safe in emails

### DIFF
--- a/news/tests/fixtures.py
+++ b/news/tests/fixtures.py
@@ -25,6 +25,7 @@ def make_entry(db):
         kwargs.setdefault("approved_at", approved_at)
         kwargs.setdefault("moderator", moderator)
         kwargs.setdefault("publish_at", publish_at)
+        kwargs.setdefault("title", "Admin User's Q3 Update")
         entry = baker.make(model_class, **kwargs)
         entry.author.set_password("password")
         entry.author.save()
@@ -64,7 +65,7 @@ def make_user(db):
         groups=None,
         password="password",
         allow_notification_others_news_posted=None,
-        **kwargs
+        **kwargs,
     ):
         user = baker.make("users.User", **kwargs)
         user.set_password(password)

--- a/news/tests/test_notifications.py
+++ b/news/tests/test_notifications.py
@@ -2,6 +2,7 @@ from datetime import date
 
 import pytest
 from django.core import mail
+from django.utils.html import escape
 from django.urls import reverse
 
 from ..models import NEWS_MODELS
@@ -27,6 +28,7 @@ def test_send_email_news_approved(rf, tp, make_entry, model_class):
     msg = mail.outbox[0]
     assert "news entry approved" in msg.subject.lower()
     assert entry.title in msg.body
+    assert escape(entry.title) not in msg.body
     assert "May 31st, 2023" in msg.body
     assert request.build_absolute_uri(entry.get_absolute_url()) in msg.body
     assert msg.recipients() == [entry.author.email]
@@ -100,6 +102,7 @@ def test_send_email_news_needs_moderation(
     msg = mail.outbox[0]
     assert "news entry needs moderation" in msg.subject.lower()
     assert entry.title in msg.body
+    assert escape(entry.title) not in msg.body
     assert entry.author.get_display_name in msg.body
     assert entry.author.email in msg.body
     assert request.build_absolute_uri(entry.get_absolute_url()) in msg.body
@@ -183,6 +186,7 @@ def test_send_email_news_posted_many_users(rf, tp, make_entry, make_user, model_
     msg = mail.outbox[0]
     assert "news entry posted" in msg.subject.lower()
     assert entry.title in msg.body
+    assert escape(entry.title) not in msg.body
     assert entry.author.email not in msg.body  # never disclose author email!
     assert request.build_absolute_uri(entry.get_absolute_url()) in msg.body
     assert request.build_absolute_uri(tp.reverse("profile-account")) in msg.body


### PR DESCRIPTION
closes #772  

- uses `mark_safe` in the notifications templates in the `news` app 
- updates fixtures and tests 