### PR TITLE
Website hosting docs

### DIFF
--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -1,0 +1,4 @@
+
+## Hosting
+
+Information about Google Cloud Platform, Amazon S3, Fastly, and related topics is covered in https://github.com/cppalliance/temp-site-documentation

--- a/docs/mailman/README.md
+++ b/docs/mailman/README.md
@@ -1,0 +1,4 @@
+
+## Mailman
+
+Information about mailman3 server instances is covered in https://github.com/cppalliance/temp-site-documentation


### PR DESCRIPTION
The current boost.org website stores internal administrative documentation in multiple locations including https://github.com/boostorg/wiki/wiki and https://github.com/boostorg/boost-tasks. When considering the topics of AWS S3, server instances, the CDN, clusters, etc. most end-users and boost developers do not need this information.  If the documentation were included in a folder of the temp-site repo, it would consume storage and slow down web deployments. So a proposal is to have a separate docs repo, https://github.com/cppalliance/temp-site-documentation  .  
