### PR TITLE
Hide release notes url when not a full release

### DIFF
--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -59,8 +59,8 @@
             </a>
           </div>
           <div class="-ml-2 h-14">
-            {% comment %}Release notes don't include beta releases{% endcomment %}
-            {% if not version.beta %}
+            {% comment %}Release notes are only for full releases {% endcomment %}
+            {% if version.full_release %}
             <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"
                href="{{ version.boost_release_notes_url }}">
               <i class="float-right mt-1 fas fa-arrow-up-right-from-square"></i>


### PR DESCRIPTION
Part of #386 

Release notes only apply to full releases, so this PR hides that URL when the release object is not a full release. 