### PR TITLE
Add `master` and `develop` links to releases page

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -462,3 +462,8 @@ ARTIFACTORY_URL = env(
 # The min Boost version is the oldest version of Boost that our import scripts
 # will retrieve. It's determined by the files we store in the archives/ in S3.
 MINIMUM_BOOST_VERSION = "1.31.0"
+
+# Boost URLS
+
+BOOST_MASTER_BRANCH = "https://github.com/boostorg/boost/tree/master"
+BOOST_DEVELOP_BRANCH = "https://github.com/boostorg/boost/tree/develop"

--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -69,6 +69,25 @@
             </a>
             {% endif %}
           </div>
+
+          <div class="-ml-2 h-14">
+            <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"
+               href="{{ version.github_url }}">
+              <i class="float-right mt-1 fab fa-github"></i>
+              <span class="dark:text-white text-slate"><code>master</code> branch</span>
+              <span class="block text-xs">{{ master_branch_url|cut:"https://" }}</span>
+            </a>
+          </div>
+
+          <div class="-ml-2 h-14">
+            <a class="block items-center py-1 px-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-slate text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange"
+               href="{{ version.github_url }}">
+              <i class="float-right mt-1 fab fa-github"></i>
+              <span class="dark:text-white text-slate"><code>develop</code> branch</span>
+              <span class="block text-xs">{{ develop_branch_url|cut:"https://" }}</span>
+            </a>
+          </div>
+
         </div>
       </div>
       <div class="overflow-x-hidden pb-2 pl-0 ml-0 space-x-6 w-full h-auto md:pb-0 md:pl-6 md:ml-6">

--- a/versions/managers.py
+++ b/versions/managers.py
@@ -41,7 +41,8 @@ class VersionManager(models.Manager):
 
     def version_dropdown(self):
         """Return the versions that should show in the version drop-down"""
-        all_versions = self.active().filter(beta=False)
+        # Includes full releases, not betas or the master/develop branch
+        all_versions = self.active().filter(full_release=True)
         most_recent = self.most_recent()
         most_recent_beta = self.most_recent_beta()
 
@@ -50,6 +51,8 @@ class VersionManager(models.Manager):
             if not most_recent_beta:
                 return False
 
+            # If the beta is for a newer version than the most recent version,
+            # show it
             return (
                 most_recent_beta.cleaned_version_parts
                 > most_recent.cleaned_version_parts

--- a/versions/tests/fixtures.py
+++ b/versions/tests/fixtures.py
@@ -21,6 +21,7 @@ def beta_version(db):
         description="Some awesome description of the library",
         release_date=datetime.date.today(),
         beta=True,
+        full_release=False,
     )
 
     # Make version download file
@@ -44,6 +45,7 @@ def version(db):
         name="boost-1.79.0",
         description="Some awesome description of the library",
         release_date=yesterday,
+        full_release=True,
     )
 
     # Make version download file
@@ -68,6 +70,7 @@ def inactive_version(db):
         description="Some old description of the library",
         release_date=yesterday,
         active=False,
+        full_release=True,
     )
 
     # Make version download file
@@ -91,6 +94,7 @@ def old_version(db):
         name="boost-1.70.0",
         description="Some awesome description of the library",
         release_date=last_year,
+        full_release=True,
     )
 
     # Make version download file

--- a/versions/views.py
+++ b/versions/views.py
@@ -1,9 +1,10 @@
 import structlog
 
+from django.conf import settings
+from django.contrib import messages
+from django.shortcuts import redirect
 from django.views.generic import DetailView
 from django.views.generic.edit import FormMixin
-from django.shortcuts import redirect
-from django.contrib import messages
 from itertools import groupby
 from operator import attrgetter
 
@@ -53,6 +54,8 @@ class VersionDetail(FormMixin, DetailView):
 
         context["heading"] = self.get_version_heading(obj, is_current_release)
         context["release_notes"] = self.get_release_notes(obj)
+        context["master_branch_url"] = settings.BOOST_MASTER_BRANCH
+        context["develop_branch_url"] = settings.BOOST_DEVELOP_BRANCH
 
         return context
 


### PR DESCRIPTION
Closes #386; in draft because this approach hasn't been approved, but the approach was based on a conversation with @4down 

- Removes `master` and `develop` from the drop-down menu since they don't have release notes or downloads 
- Adds links to the `master` and `develop` branches as settings vars, to the view, and in the UI using existing template resources 
- `master` and `develop` branches are still downloaded as Versions and exist in the database, so we can change how we handle them in the future if needed. 

<img width="1552" alt="Screenshot 2023-12-07 at 12 52 17 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/56b4bf13-0e64-466c-8754-2938e28fbf33">
<img width="245" alt="Screenshot 2023-12-07 at 12 52 24 PM" src="https://github.com/cppalliance/temp-site/assets/2286304/8bd0303b-34d7-42fe-83ab-4a3f4f0ffef3">
