### PR TITLE
863 dropdowns

### DIFF
--- a/versions/managers.py
+++ b/versions/managers.py
@@ -47,7 +47,7 @@ class VersionManager(models.Manager):
 
         def should_show_beta(most_recent, most_recent_beta):
             """Returns bool for whether to show beta version in dropdown"""
-            if not most_recent_beta:
+            if not most_recent_beta or most_recent is None:
                 return False
 
             return (
@@ -61,6 +61,13 @@ class VersionManager(models.Manager):
             return (all_versions | beta_queryset).order_by("-name")
         else:
             return all_versions.order_by("-name")
+
+    def version_dropdown_strict(self):
+        """Returns the versions to be shown in the drop-down, but does not include
+        the development branches"""
+        versions = self.version_dropdown()
+        # exclude if full_release is False and beta is False
+        return versions.exclude(full_release=False, beta=False)
 
 
 class VersionFileQuerySet(models.QuerySet):

--- a/versions/tests/test_managers.py
+++ b/versions/tests/test_managers.py
@@ -80,6 +80,56 @@ def test_version_dropdown(
     assert list(queryset) == expected
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "version_name, beta, full_release, most_recent_name, most_recent_beta_name, should_be_included",  # noqa
+    [
+        # Version is the most recent, full release
+        ("1.84.0", False, True, "1.84.0", "1.85.0.beta1", True),
+        # Version is the most recent beta, not full release
+        ("1.85.0.beta1", True, False, "1.84.0", "1.85.0.beta1", True),
+        # Version is not the most recent, not full release
+        ("1.83.0", False, False, "1.84.0", "1.85.0.beta1", False),
+        # No beta, version is full release
+        ("1.84.0", False, True, "1.84.0", None, True),
+        # No beta, version is not full release
+        ("develop", False, False, "1.84.0", None, False),
+    ],
+)
+def test_version_dropdown_strict(
+    version_name,
+    beta,
+    full_release,
+    most_recent_name,
+    most_recent_beta_name,
+    should_be_included,
+    version,
+    beta_version,
+):
+    """Test the version_dropdown_strict method"""
+
+    # Additional setup for most recent non-beta version
+    most_recent_version = Version.objects.create(
+        name=most_recent_name, beta=False, full_release=True
+    )
+    most_recent_version.save()
+
+    # Setup version instance
+    version.name = version_name
+    version.beta = beta
+    version.full_release = full_release
+    version.save()
+
+    if most_recent_beta_name:
+        beta_version.name = most_recent_beta_name
+        beta_version.beta = True
+        beta_version.full_release = False
+        beta_version.save()
+
+    queryset = Version.objects.version_dropdown_strict()
+    assert (version in queryset) == should_be_included
+
+
 def test_active_file_manager(version, inactive_version):
     assert Version.objects.active().count() == 1
     assert VersionFile.objects.active().count() == 1

--- a/versions/views.py
+++ b/versions/views.py
@@ -39,7 +39,7 @@ class VersionDetail(FormMixin, DetailView):
             context["is_current_release"] = False
             return context
 
-        context["versions"] = Version.objects.version_dropdown()
+        context["versions"] = Version.objects.version_dropdown_strict()
         downloads = obj.downloads.all().order_by("operating_system")
         context["downloads"] = {
             k: list(v)


### PR DESCRIPTION
Closes #863  

- Adds a stricter version of the manager method with the versions drop-down that excludes development branches 
- Use that version in the versions context 