### PR TITLE
Gateway IP NamedAddress

### DIFF
--- a/kube/boost/templates/gateway.yaml
+++ b/kube/boost/templates/gateway.yaml
@@ -16,6 +16,9 @@ spec:
     - name: http
       protocol: HTTP
       port: 80
+  addresses:
+    - type: NamedAddress
+      value: {{ .Values.gatewayStaticIp }}
 
 ---
 kind: HTTPRoute

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -231,5 +231,6 @@ certmap: "cppal-dev-certmap"
 managedCertName: managed-cert-cppal-dev,managed-cert-cppal-dev2
 secretCertName: boostorgcert
 ingressStaticIp: cppal-dev-ingress1
+gatewayStaticIp: cppal-dev-ingress1
 redisInstall: false
 celeryInstall: true

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -231,5 +231,6 @@ certmap: "production-certmap"
 managedCertName: managed-cert-boost-production,managed-cert-boost-production2
 secretCertName: boostorgcert
 ingressStaticIp: boost-production-ingress1
+gatewayStaticIp: "unused"
 redisInstall: false
 celeryInstall: true

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -231,5 +231,6 @@ certmap: "stage-certmap"
 managedCertName: managed-cert-boost-stage,managed-cert-boost-stage2
 secretCertName: boostorgcert
 ingressStaticIp: boost-stage-ingress1
+gatewayStaticIp: boost-stage-ingress1
 redisInstall: false
 celeryInstall: true


### PR DESCRIPTION
In the k8s Gateway API use a static rather than an ephemeral IP address, with the NamedAddress setting.