### PR TITLE
k8s: enable simultaneous Ingress/Gateway

### DIFF
--- a/kube/boost/templates/gateway.yaml
+++ b/kube/boost/templates/gateway.yaml
@@ -37,12 +37,14 @@ spec:
     - {{.Values.publicFqdn2}}
     - www.{{.Values.publicFqdn3}}
     - {{.Values.publicFqdn3}}
+    - www.{{.Values.publicFqdn4}}
+    - {{.Values.publicFqdn4}}
   rules:
     - matches:
       - path:
           value: /
       backendRefs:
-      - name: boost
+      - name: boost-gateway-svc
         port: 80
 {{ end }}
 
@@ -61,7 +63,7 @@ spec:
   targetRef:
     group: ""
     kind: Service
-    name: boost
+    name: boost-gateway-svc
 
 ---
 kind: HTTPRoute

--- a/kube/boost/templates/ingress.yaml
+++ b/kube/boost/templates/ingress.yaml
@@ -42,6 +42,10 @@ spec:
       http: *http_rules
     - host: {{ .Values.publicFqdn3 }}
       http: *http_rules
+    - host: www.{{.Values.publicFqdn4 }}
+      http: *http_rules
+    - host: {{ .Values.publicFqdn4 }}
+      http: *http_rules
 
 {{- else if eq .Values.ingressType "gce" }}
 
@@ -85,6 +89,10 @@ spec:
     - host: www.{{.Values.publicFqdn3 }}
       http: *http_rules_gcp
     - host: {{ .Values.publicFqdn3 }}
+      http: *http_rules_gcp
+    - host: www.{{.Values.publicFqdn4 }}
+      http: *http_rules_gcp
+    - host: {{ .Values.publicFqdn4 }}
       http: *http_rules_gcp
 ---
 apiVersion: networking.gke.io/v1beta1

--- a/kube/boost/templates/service-gateway.yaml
+++ b/kube/boost/templates/service-gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: boost-gateway-svc
+  labels:
+    env: {{ .Values.deploymentEnvironment }}
+    image: "{{ .Values.ImageTag }}"
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  selector:
+    app: boost
+    env: {{ .Values.deploymentEnvironment }}

--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -34,6 +34,7 @@ initCommands:
 publicFqdn: &fqdn cppal-dev.boost.cppalliance.org
 publicFqdn2: &fqdn2 boost.org
 publicFqdn3: &fqdn3 cppal-dev2.boost.cppalliance.org
+publicFqdn4: &fqdn4 boost.io
 
 Env:
   - name: DJANGO_SETTINGS_MODULE
@@ -66,9 +67,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "*.boost.org, *.boost.cppalliance.org, cppal-dev.boost.cppalliance.org, www.cppal-dev.boost.cppalliance.org, boost.org, www.boost.org, cppal-dev2.boost.cppalliance.org, www.cppal-dev2.boost.cppalliance.org"
+    value: "*.boost.org, *.boost.cppalliance.org, cppal-dev.boost.cppalliance.org, www.cppal-dev.boost.cppalliance.org, boost.org, www.boost.org, cppal-dev2.boost.cppalliance.org, www.cppal-dev2.boost.cppalliance.org, boost.io, www.boost.io"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://*.boost.cppalliance.org, https://*.boost.cppalliance.org, http://0.0.0.0, http://localhost, https://cppal-dev.boost.cppalliance.org, https://www.cppal-dev.boost.cppalliance.org, https://boost.org, https://www.boost.org, https://cppal-dev2.boost.cppalliance.org, https://www.cppal-dev2.boost.cppalliance.org"
+    value: "http://*.boost.cppalliance.org, https://*.boost.cppalliance.org, http://0.0.0.0, http://localhost, https://cppal-dev.boost.cppalliance.org, https://www.cppal-dev.boost.cppalliance.org, https://boost.org, https://www.boost.org, https://cppal-dev2.boost.cppalliance.org, https://www.cppal-dev2.boost.cppalliance.org, https://boost.io, https://www.boost.io"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -34,6 +34,7 @@ initCommands:
 publicFqdn: &fqdn boost.cppalliance.org
 publicFqdn2: &fqdn2 boost.org
 publicFqdn3: &fqdn3 preview.boost.org
+publicFqdn4: &fqdn4 boost.io
 
 Env:
   - name: DJANGO_SETTINGS_MODULE
@@ -66,9 +67,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "boost.cppalliance.org, www.boost.cppalliance.org, boost.org, www.boost.org, preview.boost.org, www.preview.boost.org"
+    value: "boost.cppalliance.org, www.boost.cppalliance.org, boost.org, www.boost.org, preview.boost.org, www.preview.boost.org, boost.io, www.boost.io"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://0.0.0.0, http://localhost, https://boost.cppalliance.org, https://www.boost.cppalliance.org, https://boost.org, https://www.boost.org, https://preview.boost.org, https://www.preview.boost.org"
+    value: "http://0.0.0.0, http://localhost, https://boost.cppalliance.org, https://www.boost.cppalliance.org, https://boost.org, https://www.boost.org, https://preview.boost.org, https://www.preview.boost.org, https://boost.io, https://www.boost.io"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS
@@ -226,11 +227,11 @@ hostAliases:
       - "mailman-cppal-dev.boost.cppalliance.org"
 
 ingressType: "gce"
-gatewayType: "none"
-certmap: "production-certmap"
+gatewayType: "gce"
+certmap: "boost-io-certmap"
 managedCertName: managed-cert-boost-production,managed-cert-boost-production2
 secretCertName: boostorgcert
 ingressStaticIp: boost-production-ingress1
-gatewayStaticIp: "unused"
+gatewayStaticIp: boost-io-ingress1
 redisInstall: false
 celeryInstall: true

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -34,6 +34,7 @@ initCommands:
 publicFqdn: &fqdn stage.boost.cppalliance.org
 publicFqdn2: &fqdn2 stage.boost.org
 publicFqdn3: &fqdn3 stage2.boost.cppalliance.org
+publicFqdn4: &fqdn4 boost.io
 
 Env:
   - name: DJANGO_SETTINGS_MODULE
@@ -66,9 +67,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "stage.boost.cppalliance.org, www.stage.boost.cppalliance.org, stage.boost.org, www.stage.boost.org, stage2.boost.cppalliance.org, www.stage2.boost.cppalliance.org"
+    value: "stage.boost.cppalliance.org, www.stage.boost.cppalliance.org, stage.boost.org, www.stage.boost.org, stage2.boost.cppalliance.org, www.stage2.boost.cppalliance.org, boost.io, www.boost.io"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://0.0.0.0, http://localhost, https://stage.boost.cppalliance.org, https://www.stage.boost.cppalliance.org, https://stage.boost.org, https://www.stage.boost.org, https://stage2.boost.cppalliance.org, https://www.stage2.boost.cppalliance.org"
+    value: "http://0.0.0.0, http://localhost, https://stage.boost.cppalliance.org, https://www.stage.boost.cppalliance.org, https://stage.boost.org, https://www.stage.boost.org, https://stage2.boost.cppalliance.org, https://www.stage2.boost.cppalliance.org, https://boost.io, https://www.boost.io"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -34,6 +34,7 @@ initCommands:
 publicFqdn: &fqdn boost.revsys.dev
 publicFqdn2: &fqdn2 boost.org
 publicFqdn3: &fqdn3 preview.boost.org
+publicFqdn4: &fqdn4 boost.io
 
 Env:
   - name: DJANGO_SETTINGS_MODULE
@@ -66,9 +67,9 @@ Env:
   - name: DJANGO_FQDN
     value: *fqdn
   - name: ALLOWED_HOSTS
-    value: "boost.revsys.dev, www.boost.revsys.dev, boost.org, www.boost.org, preview.boost.org, www.preview.boost.org"
+    value: "boost.revsys.dev, www.boost.revsys.dev, boost.org, www.boost.org, preview.boost.org, www.preview.boost.org, boost.io, www.boost.io"
   - name: CSRF_TRUSTED_ORIGINS
-    value: "http://0.0.0.0, http://localhost, https://boost.revsys.dev, https://www.boost.revsys.dev, https://boost.org, https://www.boost.org, https://preview.boost.org, https://www.preview.boost.org"
+    value: "http://0.0.0.0, http://localhost, https://boost.revsys.dev, https://www.boost.revsys.dev, https://boost.org, https://www.boost.org, https://preview.boost.org, https://www.preview.boost.org, https://boost.io, https://www.boost.io"
 
   # silence django deprecation warnings
   - name: PYTHONWARNINGS


### PR DESCRIPTION
Ingress and Gateway both place annotations on a service. To be able to activate those at the same time, and avoid conflicting annotations, create another service object in parallel.   
The reason for this is to add another domain name (as seen in the pull request) without disrupting the existing domain preview.boost.org.
