### PR TITLE
Calendar API key

### DIFF
--- a/kube/boost/values-cppal-dev-gke.yaml
+++ b/kube/boost/values-cppal-dev-gke.yaml
@@ -174,6 +174,11 @@ Env:
       secretKeyRef:
         name: mailman
         key: haystack_url
+  - name: CALENDAR_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: general-web-secrets
+        key: calendar_api_key
   - name: GITHUB_TOKEN
     valueFrom:
       secretKeyRef:

--- a/kube/boost/values-production-gke.yaml
+++ b/kube/boost/values-production-gke.yaml
@@ -174,6 +174,11 @@ Env:
       secretKeyRef:
         name: mailman
         key: haystack_url
+  - name: CALENDAR_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: general-web-secrets
+        key: calendar_api_key
   - name: GITHUB_TOKEN
     valueFrom:
       secretKeyRef:

--- a/kube/boost/values-stage-gke.yaml
+++ b/kube/boost/values-stage-gke.yaml
@@ -174,6 +174,11 @@ Env:
       secretKeyRef:
         name: mailman
         key: haystack_url
+  - name: CALENDAR_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: general-web-secrets
+        key: calendar_api_key
   - name: GITHUB_TOKEN
     valueFrom:
       secretKeyRef:

--- a/kube/boost/values.yaml
+++ b/kube/boost/values.yaml
@@ -169,6 +169,11 @@ Env:
       secretKeyRef:
         name: mailman
         key: haystack_url
+  - name: CALENDAR_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: general-web-secrets
+        key: calendar_api_key
   - name: GITHUB_TOKEN
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
  
I've created an API key in https://console.cloud.google.com/apis/credentials?referrer=search&project=boostorg-project1 named `calendar_api_key` and will send this to Lacey and Spencer.   Also it's a django env variable CALENDAR_API_KEY.  

Any key allows read access to a public calendar, even without permissions, and that's how this is working.

The boost calendar can be embedded in the website:  

```
<div class="section-body">
  <p>Below is a community maintained calendar of Boost related
  events. The release managers try to keep the release related
  portion of the calendar up to date.</p><iframe src=
  "https://www.google.com/calendar/embed?src=5rorfm42nvmpt77ac0vult9iig%40group.calendar.google.com&amp;ctz=America/Chicago"
  class="c1" width="100%" height="600" frameborder="0" scrolling=
  "no"></iframe>
</div>
```
      
and queried:  

```

#!/bin/bash

mykey=___

curl \
  "https://www.googleapis.com/calendar/v3/calendars/5rorfm42nvmpt77ac0vult9iig@group.calendar.google.com/events?key=$mykey" \
  --header 'Accept: application/json' \
  --compressed

```
     
     