### PR TITLE
Add News RSS and Atom feeds

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -28,6 +28,7 @@ from libraries.views import (
     LibraryListMini,
 )
 from mailing_list.views import MailingListDetailView, MailingListView
+from news.feeds import AtomNewsFeed, RSSNewsFeed
 from news.views import (
     AllTypesCreateView,
     BlogPostCreateView,
@@ -75,6 +76,8 @@ urlpatterns = (
         path("admin/", admin.site.urls),
         path("feed/downloads.rss", RSSVersionFeed(), name="downloads_feed_rss"),
         path("feed/downloads.atom", AtomVersionFeed(), name="downloads_feed_atom"),
+        path("feed/news.rss", RSSNewsFeed(), name="news_feed_rss"),
+        path("feed/news.atom", AtomNewsFeed(), name="news_feed_atom"),
         path(
             "accounts/social/signup/",
             CustomSocialSignupViewView.as_view(),

--- a/news/feeds.py
+++ b/news/feeds.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+from django.contrib.syndication.views import Feed
+from django.utils.feedgenerator import Atom1Feed
+from django.utils.timezone import make_aware, utc
+
+from .models import Entry
+
+
+class RSSNewsFeed(Feed):
+    """An RSS feed for Entry ("News" in the UI) items"""
+
+    title = "News"
+    link = "/news/"
+    description = "Recent news for Boost C++ Libraries."
+
+    def items(self):
+        return Entry.objects.filter(published=True).order_by("publish_at")[:100]
+
+    def item_pubdate(self, item):
+        """Returns the publish date as a timezone-aware datetime object"""
+        publish_date = item.publish_at
+        if publish_date:
+            datetime_obj = datetime.combine(publish_date, datetime.min.time())
+            aware_datetime_obj = make_aware(datetime_obj, timezone=utc)
+            return aware_datetime_obj
+
+    def item_description(self, item):
+        """Return the Entry content in the description field."""
+        return item.content
+
+    def item_title(self, item):
+        return item.title
+
+
+class AtomNewsFeed(RSSNewsFeed):
+    """The Atom feed version of the main Entry/News feed, which enables
+    the extra fields like `pubdate`
+    """
+
+    feed_type = Atom1Feed

--- a/news/tests/test_feeds.py
+++ b/news/tests/test_feeds.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta
+from django.utils.timezone import make_aware, now, utc
+from model_bakery import baker
+from ..feeds import RSSNewsFeed, AtomNewsFeed
+
+
+def test_items(make_entry):
+    earlier = now() - timedelta(days=30)
+    published_entry = make_entry(moderator=baker.make("users.User"), approved_at=now())
+    earlier_entry = make_entry(moderator=baker.make("users.User"), approved_at=earlier)
+    # Unpublished entry
+    make_entry(moderator=baker.make("users.User"), approved_at=None)
+    feed = RSSNewsFeed()
+    items = feed.items()
+    assert len(items) == 2
+    # Assert sorting
+    assert items[0] == published_entry
+    assert items[1] == earlier_entry
+
+
+def test_item_pubdate(make_entry):
+    feed = RSSNewsFeed()
+    published_entry = make_entry(moderator=baker.make("users.User"), approved_at=now())
+    expected_datetime = make_aware(
+        datetime.combine(published_entry.publish_at, datetime.min.time()), timezone=utc
+    )
+    assert feed.item_pubdate(published_entry) == expected_datetime
+
+
+def test_item_description(make_entry):
+    feed = RSSNewsFeed()
+    published_entry = make_entry(moderator=baker.make("users.User"), approved_at=now())
+    assert feed.item_description(published_entry) == published_entry.content
+
+
+def test_item_title(make_entry):
+    feed = RSSNewsFeed()
+    published_entry = make_entry(moderator=baker.make("users.User"), approved_at=now())
+    assert feed.item_title(published_entry) == published_entry.title
+
+
+def test_items_atom(make_entry):
+    feed = AtomNewsFeed()
+    published_entry = make_entry(moderator=baker.make("users.User"), approved_at=now())
+    items = feed.items()
+    assert len(items) == 1
+    assert items[0] == published_entry
+
+
+def test_item_pubdate_atom(make_entry):
+    feed = AtomNewsFeed()
+    published_entry = make_entry(moderator=baker.make("users.User"), approved_at=now())
+    expected_datetime = make_aware(
+        datetime.combine(published_entry.publish_at, datetime.min.time()), timezone=utc
+    )
+    assert feed.item_pubdate(published_entry) == expected_datetime

--- a/templates/news/list.html
+++ b/templates/news/list.html
@@ -19,7 +19,7 @@
             Or, <a href="{% url 'news-create' %}" class="whitespace-nowrap text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">Create a Post</a> to include in the feed (posts are reviewed before publication).
             {% else %}
             Signed-in users may submit items to include in the feed (posts are reviewed before publication).
-            {% endif %}
+            {% endif %} (<a href="{% url 'news_feed_rss' %}" class="whitespace-nowrap text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">RSS</a>)
           </p>
         </div>
 


### PR DESCRIPTION
Closes #339 

- Adds `/feed/news.rss` and `/feed/news.atom` 
- Includes the same fields as the original: https://www.boost.org/feed/news.rss 
- Adds a link to the News listing page 
- News RSS feed includes all published `Entry` types but we can exclude some news types if desired. 