### PR TITLE
Pull in data from community-maintained events calendar 

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -462,3 +462,7 @@ ARTIFACTORY_URL = env(
 # The min Boost version is the oldest version of Boost that our import scripts
 # will retrieve. It's determined by the files we store in the archives/ in S3.
 MINIMUM_BOOST_VERSION = "1.31.0"
+
+# Boost Google Calendar
+BOOST_CALENDAR = "5rorfm42nvmpt77ac0vult9iig@group.calendar.google.com"
+CALENDAR_API_KEY = env("CALENDAR_API_KEY", default="changeme")

--- a/config/urls.py
+++ b/config/urls.py
@@ -14,6 +14,7 @@ from ak.views import (
     OKView,
 )
 from core.views import (
+    CalendarView,
     ClearCacheView,
     DocLibsTemplateView,
     MarkdownTemplateView,
@@ -113,6 +114,8 @@ urlpatterns = (
             TemplateView.as_view(template_name="community_temp.html"),
             name="community",
         ),
+        # Boost community calendar
+        path("calendar/", CalendarView.as_view(), name="calendar"),
         # Boost versions views
         path("releases/<slug:slug>/", VersionDetail.as_view(), name="release-detail"),
         path(

--- a/core/calendar.py
+++ b/core/calendar.py
@@ -1,0 +1,92 @@
+import datetime
+from django.conf import settings
+import requests
+from collections import defaultdict
+
+from dateutil.parser import parse
+
+
+def get_calendar(min_time=None, single_events=True, order_by="startTime"):
+    """Retrieves JSON response for the Boost Google Calendar.
+
+    Args:
+    - min_time: The minimum start time to retrieve the calendar. Default is "now,"
+                which means the default behavior is to return only future events.
+                ISO format.
+    - single_events: True allows us to retrieve recurring events as individual events
+    - order_by: The order in which to retrieve and return the events
+
+    See the docs for more information on query params available to this API:
+    https://developers.google.com/calendar/api/v3/reference/events/list
+    """
+    if not min_time:
+        min_time = (
+            datetime.datetime.utcnow().isoformat() + "Z"
+        )  # 'Z' indicates UTC time
+
+    url = f"https://www.googleapis.com/calendar/v3/calendars/{settings.BOOST_CALENDAR}/events?key={settings.CALENDAR_API_KEY}&timeMin={min_time}&singleEvents={single_events}&orderBy={order_by}"
+
+    headers = {"Accept": "application/json"}
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    return response.json()
+
+
+def extract_calendar_events(calendar_data, count=50):
+    """Take the response from get_calendar() and extract the next N
+    events, where N is the count argument.
+
+    Args:
+    - calendar_data: The response from the Google Calendar events API
+    - count: The number of events to extract
+    """
+    event_data = calendar_data.get("items")
+
+    if not event_data:
+        return []
+
+    # Don't get an IndexError
+    if len(event_data) < count:
+        events = event_data
+    else:
+        events = event_data[:count]
+
+    return_data = []
+
+    for event in events:
+        start_date = event.get("start")
+        start_raw = start_date["date"] if start_date else None
+        try:
+            start = parse(start_raw)
+        except ValueError:
+            start = None
+
+        end_date = event.get("end")
+        end_raw = end_date["date"] if end_date else None
+        try:
+            end = parse(end_raw)
+        except ValueError:
+            end = None
+
+        event_dict = {
+            "start": start,
+            "end": end,
+            "name": event.get("summary"),
+            "description": event.get("description"),
+        }
+        return_data.append(event_dict)
+
+    return return_data
+
+
+def events_by_month(events):
+    """Takes the events returned by extract_calendar_events
+    and returns them organized in a dictionary by month and year
+    for display purposes.
+    """
+    events_by_month = defaultdict(list)
+    for event in events:
+        month_year = event["start"].strftime("%B %Y")
+        events_by_month[month_year].append(event)
+
+    return events_by_month

--- a/core/tests/test_calendar.py
+++ b/core/tests/test_calendar.py
@@ -1,0 +1,111 @@
+from datetime import datetime
+from dateutil.parser import parse
+from ..calendar import extract_calendar_events, events_by_month
+
+
+def test_extract_calendar_events():
+    mock_calendar_data = {
+        "items": [
+            {
+                "start": {"date": "2024-02-21"},
+                "end": {"date": "2024-02-22"},
+                "summary": "Event 1",
+                "description": "Description 1",
+            },
+            {
+                "start": {"date": "2024-02-28"},
+                "end": {"date": "2024-03-01"},
+                "summary": "Event 2",
+                "description": "Description 2",
+            },
+        ]
+    }
+
+    expected_output = [
+        {
+            "start": parse("2024-02-21"),
+            "end": parse("2024-02-22"),
+            "name": "Event 1",
+            "description": "Description 1",
+        },
+        {
+            "start": parse("2024-02-28"),
+            "end": parse("2024-03-01"),
+            "name": "Event 2",
+            "description": "Description 2",
+        },
+    ]
+    assert extract_calendar_events(mock_calendar_data, count=2) == expected_output
+
+
+def test_extract_calendar_events_empty_data():
+    # Test for empty calendar data
+    result = extract_calendar_events({"items": []})
+    assert result == []
+
+
+def test_extract_calendar_events_less_than_count():
+    # Test for the case where the number of events is less than the requested count
+    mock_calendar_data = {
+        "items": [
+            {
+                "start": {"date": "2024-02-21"},
+                "end": {"date": "2024-02-22"},
+                "summary": "Event 1",
+                "description": "Description 1",
+            }
+        ]
+    }
+    expected_output = [
+        {
+            "start": parse("2024-02-21"),
+            "end": parse("2024-02-22"),
+            "name": "Event 1",
+            "description": "Description 1",
+        }
+    ]
+    assert extract_calendar_events(mock_calendar_data, count=2) == expected_output
+
+
+def test_events_by_month():
+    input_events = [
+        {
+            "start": datetime(2024, 2, 21),
+            "end": datetime(2024, 2, 22),
+            "name": "Event1",
+            "description": "Desc1",
+        },
+        {
+            "start": datetime(2024, 3, 1),
+            "end": datetime(2024, 3, 2),
+            "name": "Event2",
+            "description": "Desc2",
+        },
+    ]
+
+    expected = {
+        "February 2024": [
+            {
+                "start": datetime(2024, 2, 21),
+                "end": datetime(2024, 2, 22),
+                "name": "Event1",
+                "description": "Desc1",
+            }
+        ],
+        "March 2024": [
+            {
+                "start": datetime(2024, 3, 1),
+                "end": datetime(2024, 3, 2),
+                "name": "Event2",
+                "description": "Desc2",
+            }
+        ],
+    }
+    assert events_by_month(input_events) == expected
+
+
+def test_events_by_month_no_events():
+    input_events = []
+
+    expected = {}
+    assert events_by_month(input_events) == expected

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -246,3 +246,8 @@ def test_docs_libs_gateway_200_html_transformed(rf, tp, mock_get_file_data):
     </div>
     """
     tp.assertResponseNotContains(legacy_body, response)
+
+
+def test_calendar(rf, tp):
+    response = tp.get("calendar")
+    tp.response_200(response)

--- a/core/views.py
+++ b/core/views.py
@@ -28,6 +28,14 @@ from .tasks import (
 logger = structlog.get_logger()
 
 
+class CalendarView(TemplateView):
+    template_name = "calendar.html"
+
+    def get(self, request, *args, **kwargs):
+        context = {"boost_calendar": settings.BOOST_CALENDAR}
+        return self.render_to_response(context)
+
+
 class ClearCacheView(UserPassesTestMixin, View):
     http_method_names = ["get"]
     login_url = "/login/"

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -35,3 +35,9 @@ This project uses environment variables to configure certain aspects of the appl
 - Specifies the name of the Amazon S3 bucket where static content is stored
 - For **local development**, obtain valid value from the Boost team.
 - In **deployed environments**, the valid value is set in `kube/boost/values.yaml` (or the environment-specific yaml file).
+
+## `CALENDAR_API_KEY`
+
+- API key for the Boost Google calendar
+- For **local development**, obtain valid value from the Boost team.
+- In **deployed environments**, the valid value is set in `kube/boost/values.yaml` (or the environment-specific yaml file).

--- a/env.template
+++ b/env.template
@@ -33,3 +33,5 @@ SERVE_FROM_DOMAIN=localhost
 # Celery settings
 CELERY_BROKER=redis://redis:6379/0
 CELERY_BACKEND=redis://redis:6379/0
+
+CALENDAR_API_KEY=changeme

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Boost Calendar{% endblock %}
+
+{% block content_wrapper %}
+<div class="flex justify-center items-center mb-4">
+    <h1 class="text-4xl">Boost Calendar</h1>
+</div>
+<div class="container px-4 my-8 mx-auto">
+    <div class="section-body">
+        <p>Below is a community maintained calendar of Boost related events. The release managers try to keep the release related portion of the calendar up to date.</p>
+        <iframe src="https://www.google.com/calendar/embed?src={{ boost_calendar }}&amp;ctz=America/Chicago" class="c1" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
+    </div>
+</div>
+{% endblock %}

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -60,83 +60,59 @@
       </div>
     </div>
 
-    <div class="px-4 mt-4 pt-8 my-12 lg:mb-4 mx-auto">
-      <div class="pb-10 bg-gray-400 dark:bg-gray-900 bg-opacity-10 rounded-md">
-        <div class="p-5 w-full">
-          <div class="my-6 ml-6">
-            <span class="inline py-1 px-3 w-auto text-sm uppercase rounded-lg md:text-base text-emerald-700 bg-emerald-200 dark:bg-opacity-10">schedule of events</span>
-          </div>
-        </div>
-        <div class="flex flex-col justify-center items-center pb-4 h-full">
-          <div class="relative mx-auto w-4/5"
-               x-data="{ activeSlide: 1, slides: [1] }">
-            <!-- Slides -->
-
-            {% comment %}<div x-show="activeSlide === 1" x-cloak
-                 class="flex items-center py-0 px-12 h-full rounded-lg">
-              <div class="w-full">
-                <h3 class="pb-2 mb-2 text-2xl capitalize border-b border-gray-400 text-orange dark:border-slate">November 2023</h3>
-                <span class="pb-1 mx-auto w-full text-sm align-left">
-                  <strong>Wednesday November 1st:</strong> Boost 1.84.0 closed for major changes
-                  <br />
-                  <div class="pt-1 pl-4 font-light">Release closed for major code changes. Still open for serious problem fixes and docs changes without release manager review.</div>
-                  <br />
-                </span>
-                <span class="pb-1 mx-auto w-full text-sm align-left">
-                  <strong>Wednesday November 8th:</strong> Boost 1.84.0 closed for beta
-                  <br />
-                  <div class="pt-1 pl-4 font-light">Release closed for all changes.</div>
-                  <br />
-                </span>
-                <span class="pb-1 mx-auto w-full text-sm align-left">
-                  <strong>Wednesday November 15th:</strong> Boost 1.84.0 beta
-                  <br />
-                  <div class="pt-1 pl-4 font-light">Beta posted for download.</div>
-                  <br />
-                </span>
-                <span class="pb-1 mx-auto w-full text-sm align-left">
-                  <strong>Thursday November 16th:</strong> Boost 1.84.0 open for bug fixes
-                  <br />
-                  <div class="pt-1 pl-4 font-light">Release open for bug fixes and documentation updates. Other changes by permission of a release manager.</div>
-                  <br />
-                </span>
-              </div>
-            </div>{% endcomment %}
-            <div x-show="activeSlide === 1" x-cloak
-                 class="flex items-center py-0 px-12 h-full rounded-lg">
-              <div class="w-full">
-                <h3 class="pb-2 mb-2 text-2xl capitalize border-b border-gray-400 text-orange dark:border-slate">December 2023</h3>
-                <span class="pb-1 mx-auto w-full text-sm align-left">
-                  <strong>Wednesday December 6th:</strong> Boost 1.84.0 closed
-                  <br />
-                  <div class="pt-1 pl-4 font-light">Release closed for all changes.</div>
-                  <br />
-                </span>
-                <span class="pb-1 mx-auto w-full text-sm align-left">
-                  <strong>Wednesday November 8th:</strong> Boost 1.84.0 release
-                  <br />
-                  <div class="pt-1 pl-4 font-light">Release posted for download.</div>
-                  <br />
-                </span>
+    {% if events %}
+        <div class="px-4 mt-4 pt-8 my-12 lg:mb-4 mx-auto">
+          <div class="pb-10 bg-gray-400 dark:bg-gray-900 bg-opacity-10 rounded-md">
+            <div class="p-5 w-full">
+              <div class="my-6 ml-6">
+                <span class="inline py-1 px-3 w-auto text-sm uppercase rounded-lg md:text-base text-emerald-700 bg-emerald-200 dark:bg-opacity-10">schedule of events</span>
               </div>
             </div>
-            <!-- Prev/Next Arrows -->
-
-            {% comment %}
-            <div class="flex absolute inset-0">
-              <div class="flex justify-start items-center w-1/2">
-                <button class="-ml-6 w-12 h-12 font-bold text-white bg-gray-400 rounded-full"
-                        x-on:click="activeSlide = activeSlide === 1 ? slides.length : activeSlide - 1">&#8592;</button>
+            <div class="flex flex-col justify-center items-center pb-4 h-full">
+              <div class="relative mx-auto w-4/5"
+              x-data="{ activeSlide: 1, slides: Array.from({ length: {{ num_months }} }, (_, i) => i + 1) }">
+                <!-- Slides -->
+                {% for month_year, month_events in events.items %}
+                <div x-show="activeSlide === {{ forloop.counter }}" x-cloak
+                    class="flex items-center py-0 px-12 h-full rounded-lg">
+                  <div class="w-full">
+                    <h3 class="pb-2 mb-2 text-2xl capitalize border-b border-gray-400 text-orange dark:border-slate">{{ month_year }}</h3>
+                    {% for event in month_events %}
+                    <span class="pb-1 mx-auto w-full text-sm align-left">
+                      <strong>{{ event.start.date }}:</strong> {{ event.name }}
+                      <br />
+                      <div class="pt-1 pl-4 font-light">{{ event.description }}</div>
+                      <br />
+                    </span>
+                    {% endfor %}
+                  </div>
+                </div>
+                {% endfor %}
+                <!-- Prev/Next Arrows -->
+                <div class="flex absolute inset-0">
+                  <div class="flex justify-start items-center w-1/2">
+                    <button
+                      x-show="activeSlide !== 1"
+                      class="-ml-6 w-12 h-12 font-bold text-white bg-gray-400 rounded-full"
+                      x-on:click="activeSlide = activeSlide === 1 ? slides.length : activeSlide - 1">
+                      &#8592;
+                    </button>
+                  </div>
+                  <div class="flex justify-end items-center w-1/2">
+                    <button
+                      x-show="activeSlide !== slides.length"
+                      class="-mr-6 w-12 h-12 font-bold text-white bg-gray-400 rounded-full"
+                      x-on:click="activeSlide = activeSlide === slides.length ? 1 : activeSlide + 1">
+                      &#8594;
+                    </button>
+                  </div>
+                </div>
               </div>
-              <div class="flex justify-end items-center w-1/2">
-                <button class="-mr-6 w-12 h-12 font-bold text-white bg-gray-400 rounded-full"
-                        x-on:click="activeSlide = activeSlide === slides.length ? 1 : activeSlide + 1">&#8594;</button>
-              </div>
-            </div>{% endcomment %}
+            </div>
           </div>
         </div>
-      </div>
-    </div>
+    {% endif %}
+
 
     {% if featured_library %}
     <div class="my-12 space-y-4 lg:flex lg:my-16 lg:space-y-0 lg:space-x-4">


### PR DESCRIPTION
Part of #760 

- Adds functions to retrieve raw events from the Google Calendar API, extract the data we need for those events, and order those events by month for display 
- Documents the new env vars 
- Adds new setting for the google calendar API url 
- Adds `/calendar/` to URLs, which displays the rendered google calendar **but didn't prettify it**
- Adds events to homepage, using the existing template 
- Edits to the homepage template to show the events and make the paging arrows work


Per the ticket, 1 and 2 are done with this PR: 

> 1. On the homepage in succinct line item form
> a. Using the same layout/functionality as the hardcoded "Schedule of Events" section currently on the new homepage or
> b. If there is a suggestion or idea for something that might work better, we should discuss.

> 2. On a new page where it can be displayed more fully as it currently works at the old site (but looking nicer than how it looks on the old site - looked like the example shown during the 10/27 meeting would work)

except that the design is the Google calendar default 

### calendar page 

![Screenshot 2023-12-22 at 1 50 42 PM](https://github.com/cppalliance/temp-site/assets/2286304/026969f6-df76-4a04-a621-19a3ba57c197) 

### homepage 
![Screenshot 2023-12-22 at 1 51 32 PM](https://github.com/cppalliance/temp-site/assets/2286304/e460e255-8120-4fff-a55f-b89daa4ae200)
![Screenshot 2023-12-22 at 1 51 46 PM](https://github.com/cppalliance/temp-site/assets/2286304/453c00d0-b98d-4681-8627-eb2e675024ed)


NOTE: Still needs caching; will come in a PR after the holidays 


