### PR TITLE
Add event caching, add event docs

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -466,3 +466,5 @@ MINIMUM_BOOST_VERSION = "1.31.0"
 # Boost Google Calendar
 BOOST_CALENDAR = "5rorfm42nvmpt77ac0vult9iig@group.calendar.google.com"
 CALENDAR_API_KEY = env("CALENDAR_API_KEY", default="changeme")
+EVENTS_CACHE_KEY = "homepage_events"
+EVENTS_CACHE_TIMEOUT = 300  # 5 min

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [Dependency Management](./dependencies.md)
 - [Development Setup Notes](./development_setup_notes.md)
 - [Environment Variables](./env_vars.md)
+- [Events Calendar](./calendar.md)
 - [Example Files](./examples/README.md) - Contains samples of `libraries.json`. `.gitmodules`, and other files that Boost data depends on
 - [Hosting](./hosting/README.md)
 - [Mailman](./mailman/README.md)

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -1,0 +1,9 @@
+# Events Calendar
+
+The "Schedule of Events" section on the homepage dynamically display upcoming events from the Boost Google Calendar. See the settings in [Environment Variables](./env_vars.md).
+
+- See the settings in [Environment Variables](./env_vars.md).
+- Main code for event retrieval is in `core/calendar.py`
+- Raw data is extracted from the Google Calendar API
+- The raw data is processed to extract the event data that we want to display, and sorted into the order we want
+- The home page caches the result, and attempts to retrieve the events from the cache before hitting the Google Calendar API

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -36,8 +36,19 @@ This project uses environment variables to configure certain aspects of the appl
 - For **local development**, obtain valid value from the Boost team.
 - In **deployed environments**, the valid value is set in `kube/boost/values.yaml` (or the environment-specific yaml file).
 
-## `CALENDAR_API_KEY`
+## Boost Google Calendar settings
+
+### `BOOST_CALENDAR`
+
+- Address for the Boost Google Calendar
+- Hard-coded in `settings.py` in all environments
+### `CALENDAR_API_KEY`
 
 - API key for the Boost Google calendar
 - For **local development**, obtain valid value from the Boost team.
 - In **deployed environments**, the valid value is set in `kube/boost/values.yaml` (or the environment-specific yaml file).
+
+### `EVENTS_CACHE_KEY` and `EVENTS_CACHE_TIMEOUT`
+
+- The cache key and timeout length for the Google Calendar events
+- Hard-coded in `settings.py` in all environments


### PR DESCRIPTION
Part of #760 

Adds caching for google events calendar, adds docs about how those events are retrieved 