### PR TITLE
Remove extra slash from artifactory download links 

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -458,6 +458,7 @@ CORS_ALLOW_HEADERS = (
 ARTIFACTORY_URL = env(
     "ARTIFACTORY_URL", default="https://boostorg.jfrog.io/artifactory/api/storage/main/"
 )
+MIN_ARTIFACTORY_RELEASE = "boost-1.63.0"
 
 # The min Boost version is the oldest version of Boost that our import scripts
 # will retrieve. It's determined by the files we store in the archives/ in S3.

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -36,6 +36,19 @@ This project uses environment variables to configure certain aspects of the appl
 - For **local development**, obtain valid value from the Boost team.
 - In **deployed environments**, the valid value is set in `kube/boost/values.yaml` (or the environment-specific yaml file).
 
+## Boost Release Downloads Settings
+
+### `ARTIFACTORY_URL`
+
+- Base API endpoint for accessing the JFrog Artifactory release downloads. This is NOT the base URL for the downloads themselves.
+- For **local development**, there is a default value in `config/settings.py`
+- In **deployed environments**, the valid value is set in `kube/boost/values.yaml` (or the environment-specific yaml file).
+
+### `MIN_ARTIFACTORY_RELEASE`
+
+- The lowest version of Boost with its downloads stored in JFrog Artifactory
+- Hard-coded in `config/settings.py` in all environments
+
 ## Boost Google Calendar settings
 
 ### `BOOST_CALENDAR`

--- a/docs/release_downloads.md
+++ b/docs/release_downloads.md
@@ -1,0 +1,12 @@
+# Boost Release Downloads
+
+## Artifactory
+
+- Populate the release downloads by running `./manage.py import_artifactory_release_data`. See [Management Commands](./commands.md#import_artifactory_release_data) for more information.
+- Downloads for new versions populate as part of the new version import process
+- Existing data can be refreshed by running `./manage.py import_artifactory_release_data` in the desired environment
+- Environment variables: `ARTIFACTORY_URL` and `MIN_ARTIFACTORY_RELEASE`. See the [Envrionment Variables](./env_vars.md) for more information.
+
+The Artifactory API URL in `ARTIFACTORY_URL` allows us to retrieve the data about the downloads from the Artifactory API.
+
+The URLs for the downloads themselves are retrieved from the URLs provided to us by the Artifactory API. We don't generate the download links ourselves.

--- a/versions/management/commands/import_artifactory_release_data.py
+++ b/versions/management/commands/import_artifactory_release_data.py
@@ -2,6 +2,8 @@ import djclick as click
 
 import requests
 
+from django.conf import settings
+
 from versions.models import Version
 from versions.releases import (
     get_artifactory_download_data,
@@ -20,7 +22,7 @@ def command(release):
     specified release. If no release is specified, it will import the release data
     for all releases included in Artifactory.
     """
-    last_release = "boost-1.63.0"
+    last_release = settings.MIN_ARTIFACTORY_RELEASE
 
     if release:
         versions = Version.objects.filter(name__icontains=release)

--- a/versions/releases.py
+++ b/versions/releases.py
@@ -65,7 +65,7 @@ def get_artifactory_downloads_for_release(release: str = "1.81.0") -> list:
             continue
 
         if any(uri.endswith(ext) for ext in file_extensions):
-            uris.append(f"{base_uri}/{uri}")
+            uris.append(f"{base_uri}{uri}")
 
     return uris
 

--- a/versions/tests/test_releases.py
+++ b/versions/tests/test_releases.py
@@ -17,10 +17,10 @@ def test_get_artifactory_downloads_for_release():
     url = f"{settings.ARTIFACTORY_URL}release/{version_num}/source/"
     data = {
         "children": [
-            {"uri": "boost_1_81_0.tar.bz2"},  # include
-            {"uri": "boost_1_81_0-rc.tar.gz"},  # exclude, release candidate
-            {"uri": "boost_1_81_0-beta.tar.gz"},  # exclude, beta
-            {"uri": "boost_1_81_0.html"},  # exclude, wrong extension
+            {"uri": "/boost_1_81_0.tar.bz2"},  # include
+            {"uri": "/boost_1_81_0-rc.tar.gz"},  # exclude, release candidate
+            {"uri": "/boost_1_81_0-beta.tar.gz"},  # exclude, beta
+            {"uri": "/boost_1_81_0.html"},  # exclude, wrong extension
         ]
     }
     responses.add(responses.GET, url, json=data)
@@ -35,10 +35,10 @@ def test_get_artifactory_downloads_for_release_beta():
     url = f"{settings.ARTIFACTORY_URL}beta/{version_num}/source/"
     data = {
         "children": [
-            {"uri": "boost_1_81_0.tar.bz2"},  # include, because not excluded
-            {"uri": "boost_1_81_0-rc.tar.gz"},  # exclude, release candidate
-            {"uri": "boost_1_81_0-beta.tar.gz"},  # include, beta
-            {"uri": "boost_1_81_0.html"},  # exclude, wrong extension
+            {"uri": "/boost_1_81_0.tar.bz2"},  # include, because not excluded
+            {"uri": "/boost_1_81_0-rc.tar.gz"},  # exclude, release candidate
+            {"uri": "/boost_1_81_0-beta.tar.gz"},  # include, beta
+            {"uri": "/boost_1_81_0.html"},  # exclude, wrong extension
         ]
     }
     responses.add(responses.GET, url, json=data)


### PR DESCRIPTION
Part of #878  

New link: `[boost_1_83_0.tar.gz](https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.gz)` 

Admin screenshot: 
<img width="1007" alt="Screenshot 2024-01-10 at 11 13 42 AM" src="https://github.com/cppalliance/temp-site/assets/2286304/7fe654d3-4610-4477-8c0b-acce1cd0eac2">
