### PR TITLE
Replace relative image URLs with fully-qualified paths for static content

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -17,6 +17,7 @@ from core.views import (
     CalendarView,
     ClearCacheView,
     DocLibsTemplateView,
+    ImageView,
     MarkdownTemplateView,
     StaticContentTemplateView,
     UserGuideTemplateView,
@@ -277,6 +278,12 @@ urlpatterns = (
             r"^markdown/(?P<content_path>.+)/?",
             MarkdownTemplateView.as_view(),
             name="markdown-page",
+        ),
+        # Images from static content
+        re_path(
+            r"^images/(?P<content_path>.+)/?",
+            ImageView.as_view(),
+            name="images-page",
         ),
         # Static content
         re_path(

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -47,6 +47,7 @@ def refresh_content_from_s3(s3_key, cache_key):
     """Calls S3 with the s3_key, then saves the result to the
     RenderedContent object with the given cache_key."""
     content_dict = get_content_from_s3(key=s3_key)
+
     content = content_dict.get("content")
     if content_dict and content:
         content_type = content_dict.get("content_type")

--- a/core/tests/test_renderer.py
+++ b/core/tests/test_renderer.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup
 from unittest.mock import Mock, patch
 import datetime
 from io import BytesIO
@@ -9,6 +10,7 @@ from ..boostrenderer import (
     get_content_type,
     get_file_data,
     get_s3_keys,
+    convert_img_paths,
 )
 
 
@@ -109,6 +111,8 @@ def test_get_file_data():
 
 def test_get_s3_keys():
     """
+    Test cases for get_s3_keys function.
+
     Test cases:
 
     - "/marshmallow/index.html" -> "site/develop/tools/auto_index/index.html"
@@ -116,7 +120,6 @@ def test_get_s3_keys():
     - "/rst.css" -> "site/develop/rst.css"
     - "/site/develop/doc/html/about.html" -> "site/develop/doc/html/about.html"
     """
-
     assert "/site-docs/develop/user-guide/index.html" in get_s3_keys(
         "/doc/user-guide/index.html"
     )
@@ -129,3 +132,30 @@ def test_get_s3_keys():
     assert "/site-docs/develop/release-process/index.html" in get_s3_keys(
         "/doc/release-process/index.html"
     )
+
+
+def test_convert_img_paths():
+    # Test data
+    html_content = """
+        <html>
+            <body>
+                <img src="image1.png" alt="Image 1"/>
+            </body>
+        </html>
+    """
+
+    # Expected output after conversion
+    expected_html = """
+        <html>
+            <body>
+                <img src="/images/site-pages/develop/image1.png" alt="Image 1"/>
+            </body>
+        </html>
+    """  # noqa
+    s3_path = "/images/site-pages/develop"
+
+    result = convert_img_paths(html_content, s3_path)
+
+    expected_soup = BeautifulSoup(expected_html, "html.parser")
+    result_soup = BeautifulSoup(result, "html.parser")
+    assert result_soup == expected_soup

--- a/docs/static_content.md
+++ b/docs/static_content.md
@@ -1,10 +1,47 @@
-# Retrieving Static Content from the Boost Amazon S3 Bucket
+# Boost Static Content
 
-The `StaticContentTemplateView` class (in the `core/` app) is a Django view that handles requests for static content.
+**Static Content** refers to content such as HTML files, markdown files, asciidoc files, etc. that is retrieved from Amazon S3 and rendered within the Boost site.
+
+We can add "shortcut" URL paths to specific directories or files within S3 by updating the file `stage_static_config.json`.
+
+## Quick Start
+
+### Adding a shortcut url to a static page
+
+1. Identify the URL pattern you would like to use. Example: `/style-guide/`
+2. Identify the S3 path to the file you would like that URL to load. Example: `/site-pages/develop/style-guides.adoc`
+3. Add an entry to `stage_static_config.json`. `site_path` is your URL route, with a `/` on either side. `s3_path` is the path to your desired file in S3, with a leading `/`:
+
+```javascript
+  ...
+  },
+  {
+    "site_path": "/style-guide/",
+    "s3_path": "/site-pages/develop/style-guides.adoc"
+  },
+  {
+  ...
+```
+
+4. Restart your server and load `/style-guide/` in your browser to confirm it works.
+
+## About Retrieving Static Content
+
+An example shortcut url is the `/help/` page. This is the route that the `/help/` URL takes to render that page:
+
+- The user enters `/help/` into the browser
+- There is no `help/` path in `config/urls.py`, so the route falls through to the view that handles static content, `StaticContentTemplateView`.
+- In this view, the `content_path` will be `help` . The view uses the `content_path` to try and retrieve the content for the `/help/` page from the Redis cache, the `RenderedContent` table, or from Amazon S3.
+- The logic for retrieving the content from Amazon S3 is stored in `core/boostrenderer.py::get_content_from_s3()`. See [Retrieving Static Content from the Boost Amazon S3 Bucket](#retrieving-static-content-from-the-boost-amazon-s3-bucket) and [How we decide which S3 keys to try](#how-we-decide-which-s3-keys-to-try) for more information.
+- Back in the view, if the view receives content from S3 (or the Redis cache or the database), it will return that. Otherwise, a 404 is raised.
+
+## Retrieving Static Content from the Boost Amazon S3 Bucket
+
+The `StaticContentTemplateView` class (in the `core/` app) is a Django view that handles requests for static content. It inherits from `BaseStaticContentTemplateView`, which is the class that contains the bulk of the logic.
 
 Its URL path is the very last path in our list of URL patterns (see `config/urls.py`) because it functions as the fallback URL pattern. If a user enters a URL that doesn't match anything else defined in our URL patterns, this view will attempt to retrieve the request as static content from S3 using the URL path.
 
-The `StaticContentTemplateView` calls S3 using the URL pattern and generates a list of potential keys to check. It then checks the specified S3 bucket for each of those keys and returns the first match it finds, along with the file content type. Passing the content type with the bucket contents allows the content to be delivered appropriately to the user (so HTML files will be rendered as HTML, etc.)
+`StaticContentTemplateView` calls S3 using the URL pattern. The S3 retrieval code in `core/boostrenderer.py::get_content_from_s3()` generates a list of potential keys to check. It then checks the specified S3 bucket for each of those keys and returns the first match it finds, along with the file content type. Passing the content type with the bucket contents allows the content to be delivered appropriately to the user (so HTML files will be rendered as HTML, etc.)
 
 Boost uses the AWS SDK for Python (boto3) to connect to an S3 bucket and retrieve the static content. If no bucket name is provided, pur process uses the `STATIC_CONTENT_BUCKET_NAME` setting from the Django project settings.
 
@@ -33,6 +70,10 @@ Take a look at this sample `{env}_static_config.json` file:
         "s3_path": "/site/develop/doc/html/"
     },
     {
+      "site_path": "/doc/_/",
+      "s3_path": "/site-docs/develop/_/"
+    },
+    {
         "site_path": "/",
         "s3_path": "/site/develop/"
     }
@@ -43,12 +84,21 @@ Take a look at this sample `{env}_static_config.json` file:
 
 - `/site/develop/libs/index.html`
 
+Note that the `site_path` and the `s3_path` don't have to be to the same depth; the `site_path` in this example is 2 levels deep, and the `s3_path` is 3 levels deep. It doesn't matter.
+
 **Example 2**: If the URL request is for `/develop/doc/index.html`, the S3 keys that the function would try are:
 
 - `/site/develop/doc/html/index.html`
 - `/site/develop/doc/index.html`
 
-**Example 3**: If the URL request is for `/index.html`, the S3 keys that the function would try are:
+**Example 3**: If the url request is for `/doc/accumulators/`, the S3 keys that the function would try are:
+
+- `/site-docs/develop/accumulators/`
+- `/site-docs/develop/accumulators/index.html`
+
+In this example, the `_` functions as a wildcard, so `/doc/accumulators/` would shortcut to `/site-docs/develop/accumulators/`, and `/doc/algorithm/` would shortcut to `/site-docs/develop/algorithm/`, even though neither `accumulators` nor `algorithm` have their own entries in the config file.
+
+**Example 4**: If the URL request is for `/index.html`, the S3 keys that the function would try are:
 
 - `/site/develop/index.html`
 - `/site/index.html`
@@ -59,4 +109,4 @@ We first try to retrieve the static content using the exact S3 key specified in 
 
 See [Caching and the `RenderedContent` model](./caching_rendered_content.md) for how Django-side caching is handled.
 
-Cacching is also handled via Fastly CDN.
+Caching is also handled via Fastly CDN.

--- a/libraries/tests/test_tasks.py
+++ b/libraries/tests/test_tasks.py
@@ -19,11 +19,11 @@ def test_get_and_store_library_version_documentation_urls_for_version(
     library_name = library.name.lower()
     mock_s3_response = {
         "content": f"""
-            <h2>Libraries Listed <a name="Alphabetically">Alphabetically</a></h2>
-            <ul>
-                <li><a href="{library_name}/index.html">{library_name}</a></li>
-            </ul>
-        """
+        <h2>Libraries Listed <a name="Alphabetically">Alphabetically</a></h2>
+        <ul>
+            <li><a href="{library_name}/index.html">{library_name}</a></li>
+        </ul>
+    """
     }
 
     # Mock the get_content_from_s3 function to return the mock S3 response


### PR DESCRIPTION
Closes #886 

### In this PR: 

- A new URL route for images from S3: `/images/`. This route will allow us to access images directly from S3 while still masking the S3 key. Example URL: `http://localhost:8000/images/site-pages/develop/url-style-guide-image.png` 
- Converted the existing `StaticContentView` into a base class, so I could add extra processing to the HTML produced by the static content without affecting the other views (like the library docs view) that inherit from the `StaticContentView`. The library docs, for example, have their own HTML processing that was easily disrupted and not easily debugged. 
- The new `StaticContentView` now inherits from the `BaseStaticContentView`, and does its own processing to replace the image URLs with fully-qualified paths to the `/images/` view (and thus, directly to S3)
- The helper function `convert_img_paths`, which does the actual extracting of the image URLs and replacing them 

@4down Will you check out this branch and test it locally to make sure these changes didn't break anything? Before I merge, I'll also remove the `/style/` shortcut from the config file -- that was just a proof of concept file that contains an image. 

Please clear your cache, and clear your local `RenderedContents` table`, so each page is loading fresh. 

URLs I tested: 

- The shortcut URL from the config to a file that contains an image: http://localhost:8000/style/
- A URL that uses a shortcut to a path from the config, that leads to the same file: http://localhost:8000/page/style-guides.adoc
- Current release notes: http://localhost:8000/doc/libs/boost_1_84_0/index.html
- Old release notes: http://localhost:8000/doc/libs/boost_1_57_0/index.html
- Current library docs: http://localhost:8000/doc/libs/boost_1_84_0/libs/algorithm/doc/html/index.html
- Old library docs: http://localhost:8000/doc/libs/boost_1_68_0/index.html
- An existing shortcut route from the config file: http://localhost:8000/help/
- A path directly to an image: http://localhost:8000/page/url-style-guide-image.png
- A path using the Images URL to an image: http://localhost:8000/images/site-pages/develop/url-style-guide-image.png

I did not test a file that contains an image whose path is nested, and there are probably other cases I haven't tested. If it looks good, then I'll remove my proof-of-concept route, clean up the commits, and merge it. 