### PR TITLE
package.json updated for exact versions of tw/forms and tw

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "builduserguide": "NODE_ENV=production tailwindcss -c ./userguidetailwind.config.js -i frontend/userguidestyles.css -o static/css/userguidestyles.css --minify"
   },
   "dependencies": {
-    "@tailwindcss/forms": "^0.5.3",
+    "@tailwindcss/forms": "0.5.3",
     "alpinejs": "^3.10.2",
     "autoprefixer": "^10.4.12",
     "cssnano": "^5.1.14",
     "htmx": "^0.0.2",
-    "tailwindcss": "^3.2.1"
+    "tailwindcss": "3.2.1"
   }
 }


### PR DESCRIPTION
- tailwindcss pinned to 3.2.1
- @tailwindcss/forms pinned to 0.5.3

Default behavior when adding a package using npm results in the version syntax in package.json where it uses the caret, which keeps the versions in the same major release but easily leads to different versions existing on different envs.  

Using ie. `npm i tailwindcss@3.2.1 --save --save-exact` keeps the package at an exact version. 