### PR TITLE
Truncate latest + homepage and news list

### DIFF
--- a/core/templatetags/text_helpers.py
+++ b/core/templatetags/text_helpers.py
@@ -1,5 +1,6 @@
 from django import template
 from django.template.defaultfilters import stringfilter
+import re
 
 register = template.Library()
 
@@ -15,6 +16,30 @@ def truncate_middle(value, arg):
         return value
     else:
         return f"{value[:ln//2]}....{value[-((ln+1)//2):]}"
+
+
+@register.filter(is_safe=True)
+@stringfilter
+def multi_truncate_middle(value, arg):
+    def replace_match(match):
+        word = match.group(0)
+        if len(word) > ln:
+            start = word[: ln // 2]
+            end = word[-((ln + 1) // 2) :]
+            return f"{start}...{end}"
+        return word
+
+    pattern = re.compile(r"\b\w+\b")
+
+    try:
+        ln = int(arg)
+    except ValueError:
+        return value
+    if len(value) <= ln:
+        return value
+    else:
+        result = pattern.sub(replace_match, value)
+        return result
 
 
 @register.filter(is_safe=True)

--- a/core/templatetags/text_helpers.py
+++ b/core/templatetags/text_helpers.py
@@ -22,14 +22,34 @@ def truncate_middle(value, arg):
 @stringfilter
 def multi_truncate_middle(value, arg):
     def replace_match(match):
-        word = match.group(0)
+        word_or_link = match.group(0)
+
+        link_inner_match = re.search(r"<a\b[^>]*>(.*?)<\/a>", word_or_link)
+
+        if link_inner_match:
+            word = re.sub(r"https?://", "", link_inner_match.group(1))
+
+        else:
+            word = word_or_link
+
+        print(word_or_link)
+
         if len(word) > ln:
             start = word[: ln // 2]
             end = word[-((ln + 1) // 2) :]
-            return f"{start}....{end}"
+            truncated_word = f"{start}....{end}"
+            if link_inner_match:
+                return re.sub(
+                    r"(<a\b[^>]*>)(.*?)(<\/a>)",
+                    r"\1" + truncated_word + r"\3",
+                    word_or_link,
+                )
+            return truncated_word
         return word
 
-    pattern = re.compile(r"\b\w+\b")
+    pattern = re.compile(
+        r"\b(\w{" + str(arg) + r",})\b|<a\b[^>]*>((.|\n|\r|(\n\r))*?)<\/a>"
+    )
 
     try:
         ln = int(arg)

--- a/core/templatetags/text_helpers.py
+++ b/core/templatetags/text_helpers.py
@@ -26,7 +26,7 @@ def multi_truncate_middle(value, arg):
         if len(word) > ln:
             start = word[: ln // 2]
             end = word[-((ln + 1) // 2) :]
-            return f"{start}...{end}"
+            return f"{start}....{end}"
         return word
 
     pattern = re.compile(r"\b\w+\b")

--- a/core/templatetags/text_helpers.py
+++ b/core/templatetags/text_helpers.py
@@ -34,18 +34,22 @@ def multi_truncate_middle(value, arg):
 
         print(word_or_link)
 
-        if len(word) > ln:
-            start = word[: ln // 2]
-            end = word[-((ln + 1) // 2) :]
-            truncated_word = f"{start}....{end}"
-            if link_inner_match:
+        if link_inner_match:
+            if len(word) > ln + 10:
+                start = word[: ((ln + 10) // 2)]
+                end = word[-(((ln + 10) + 1) // 2) :]
+                truncated_word = f"{start}....{end}"
                 return re.sub(
                     r"(<a\b[^>]*>)(.*?)(<\/a>)",
                     r"\1" + truncated_word + r"\3",
                     word_or_link,
                 )
+        elif len(word) > ln:
+            start = word[: (ln // 2)]
+            end = word[-((ln + 1) // 2) :]
+            truncated_word = f"{start}....{end}"
             return truncated_word
-        return word
+        return word_or_link
 
     pattern = re.compile(
         r"\b(\w{" + str(arg) + r",})\b|<a\b[^>]*>((.|\n|\r|(\n\r))*?)<\/a>"

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1464,10 +1464,6 @@ code,
   margin-left: 0.25rem;
 }
 
-.ml-\[40px\] {
-  margin-left: 40px;
-}
-
 .mr-1 {
   margin-right: 0.25rem;
 }
@@ -3543,6 +3539,10 @@ code,
 
   .md\:mt-8 {
     margin-top: 2rem;
+  }
+
+  .md\:ml-\[40px\] {
+    margin-left: 40px;
   }
 
   .md\:mb-10 {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1456,6 +1456,18 @@ code,
   margin-bottom: 1.5rem;
 }
 
+.mr-4 {
+  margin-right: 1rem;
+}
+
+.ml-1 {
+  margin-left: 0.25rem;
+}
+
+.ml-\[40px\] {
+  margin-left: 40px;
+}
+
 .mr-1 {
   margin-right: 0.25rem;
 }
@@ -1504,10 +1516,6 @@ code,
   margin-left: 0px;
 }
 
-.ml-1 {
-  margin-left: 0.25rem;
-}
-
 .mr-3 {
   margin-right: 0.75rem;
 }
@@ -1530,10 +1538,6 @@ code,
 
 .-mr-4 {
   margin-right: -1rem;
-}
-
-.mr-4 {
-  margin-right: 1rem;
 }
 
 .ml-auto {
@@ -1620,6 +1624,10 @@ code,
   height: 3rem;
 }
 
+.h-\[30px\] {
+  height: 30px;
+}
+
 .h-0 {
   height: 0px;
 }
@@ -1634,10 +1642,6 @@ code,
 
 .h-14 {
   height: 3.5rem;
-}
-
-.h-\[30px\] {
-  height: 30px;
 }
 
 .h-\[25px\] {
@@ -1722,6 +1726,10 @@ code,
   width: 80px;
 }
 
+.w-\[30px\] {
+  width: 30px;
+}
+
 .w-48 {
   width: 12rem;
 }
@@ -1744,10 +1752,6 @@ code,
 
 .w-96 {
   width: 24rem;
-}
-
-.w-\[30px\] {
-  width: 30px;
 }
 
 .w-2\/3 {
@@ -2166,12 +2170,6 @@ code,
 
 .overflow-y-hidden {
   overflow-y: hidden;
-}
-
-.truncate {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .whitespace-normal {
@@ -2887,6 +2885,11 @@ code,
   color: rgb(14 174 96 / var(--tw-text-opacity));
 }
 
+.text-gray-500 {
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity));
+}
+
 .text-black {
   --tw-text-opacity: 1;
   color: rgb(5 26 38 / var(--tw-text-opacity));
@@ -2944,11 +2947,6 @@ code,
 .text-red-500 {
   --tw-text-opacity: 1;
   color: rgb(239 68 68 / var(--tw-text-opacity));
-}
-
-.text-gray-500 {
-  --tw-text-opacity: 1;
-  color: rgb(107 114 128 / var(--tw-text-opacity));
 }
 
 .text-green {
@@ -3332,13 +3330,13 @@ code,
   color: rgb(255 255 255 / 0.6);
 }
 
+.dark .dark\:text-white\/70 {
+  color: rgb(255 255 255 / 0.7);
+}
+
 .dark .dark\:text-sky-600 {
   --tw-text-opacity: 1;
   color: rgb(2 132 199 / var(--tw-text-opacity));
-}
-
-.dark .dark\:text-white\/70 {
-  color: rgb(255 255 255 / 0.7);
 }
 
 .dark .dark\:text-white\/50 {

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -204,7 +204,7 @@
               </h2>
               <p class="pt-0 pb-4 mx-auto w-full text-xs align-left">Posted on {{ entry.publish_at|date:"M jS, Y" }} by {{ entry.author.get_full_name }}</p>
               {% if entry.content %}
-              <div class="ml-[40px]">
+              <div class="md:ml-[40px]">
                 <span class="text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|multi_truncate_middle:20|truncatechars:500 }}</span>
                 </div>
               {% endif %}

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -186,13 +186,28 @@
         <div class="space-y-4">
           {% for entry in entries %}
             <div class="pt-0">
-              <h3 class="pb-2 mb-4 text-3xl capitalize border-b border-gray-400 text-orange dark:border-slate"><a href="{% url 'news-detail' slug=entry.slug %}" class="link-header">{{ entry.title }}</a></h3>
+              <h2 class="pb-2 mb-3 text-3xl font-semibold mr-4 border-b border-gray-400 dark:border-slate">
+                <div class="inline-block pt-2 mt-4 text-xs">
+                  {% if entry.author.image %}
+                    <span class="inline-block h-[30px] w-[30px] overflow-hidden rounded border border-gray-400 dark:border-gray-500">
+                      <img src="{{ entry.author.image.url }}" alt="{{ entry.author.get_full_name }}" class="h-full w-full object-cover" />
+                    </span>
+                  {% else %}
+                    <span class="inline-block h-[30px] w-[30px] bg-white rounded dark:text-white dark:bg-slate border border-gray-400 dark:border-gray-500">
+                      <i class="text-2xl fas fa-user ml-1" title="{{ entry.author.get_full_name }}"></i>
+                    </span>
+                  {% endif %}
+                </div>
+                <a class="link-header" {% if entry.tag == "link" %}target="_blank"{% endif %} href="{% if entry.tag == "link" %}{{ entry.external_url }}{% else %}{{ entry.get_absolute_url }}{% endif %}">
+                  {{ entry.title }}
+                </a>
+              </h2>
+              <p class="pt-0 pb-4 mx-auto w-full text-xs align-left">Posted on {{ entry.publish_at|date:"M jS, Y" }} by {{ entry.author.get_full_name }}</p>
               {% if entry.content %}
-              <div class="truncate">
-              <span class="pb-1 mx-auto w-full text-lg align-left">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|truncatechars:500 }}...</span>
-              </div>
+              <div class="ml-[40px]">
+                <span class="text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|multi_truncate_middle:20|truncatechars:500 }}</span>
+                </div>
               {% endif %}
-              <p class="pb-1 mx-auto w-full text-xs align-left"><i>Published on {{ entry.publish_at|date:"m/d/Y" }} by {{ entry.author.get_full_name }}</i></p>
             </div>
           {% endfor %}
         </div>

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -205,7 +205,7 @@
               <p class="pt-0 pb-4 mx-auto w-full text-xs align-left">Posted on {{ entry.publish_at|date:"M jS, Y" }} by {{ entry.author.get_full_name }}</p>
               {% if entry.content %}
               <div class="md:ml-[40px]">
-                <span class="text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|multi_truncate_middle:20|truncatechars_html:500 }}</span>
+                <span class="text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|multi_truncate_middle:30|truncatechars_html:500 }}</span>
                 </div>
               {% endif %}
             </div>

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -205,7 +205,7 @@
               <p class="pt-0 pb-4 mx-auto w-full text-xs align-left">Posted on {{ entry.publish_at|date:"M jS, Y" }} by {{ entry.author.get_full_name }}</p>
               {% if entry.content %}
               <div class="md:ml-[40px]">
-                <span class="text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|multi_truncate_middle:20|truncatechars:500 }}</span>
+                <span class="text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|multi_truncate_middle:20|truncatechars_html:500 }}</span>
                 </div>
               {% endif %}
             </div>

--- a/templates/news/list.html
+++ b/templates/news/list.html
@@ -147,7 +147,7 @@
             </div>
             {% if entry.content %}
             <div>
-              <span class="text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|multi_truncate_middle:20|truncatechars:500 }}</span>
+              <span class="text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|multi_truncate_middle:20|truncatechars_html:500 }}</span>
               </div>
             {% endif %}
 

--- a/templates/news/list.html
+++ b/templates/news/list.html
@@ -147,7 +147,7 @@
             </div>
             {% if entry.content %}
             <div>
-              <span class="text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|truncatechars:500 }}...</span>
+              <span class="text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|multi_truncate_middle:20|truncatechars:500 }}</span>
               </div>
             {% endif %}
 

--- a/templates/news/list.html
+++ b/templates/news/list.html
@@ -147,7 +147,7 @@
             </div>
             {% if entry.content %}
             <div>
-              <span class="text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|multi_truncate_middle:20|truncatechars_html:500 }}</span>
+              <span class="text-base text-gray-500 dark:text-white/70">{{ entry.content|urlize|url_target_blank:'text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange'|linebreaksbr|multi_truncate_middle:30|truncatechars_html:500 }}</span>
               </div>
             {% endif %}
 


### PR DESCRIPTION
- resolves #893 
- resolves #837 

Adds filter multi_truncate_middle to update exceptionally-long strings inside of news text to have a "..." in the middle of the string.  

Modified layout and styles on the homepage news listing, brought over styles from the news listing and added a slight indent / added author image next to title to try to make the section look better as a standalone section.

Will need to fine-tune the argument passed which sets the length a string needs to be for this to kick in after seeing it in action with more actual data most likely.  Possible issue which will get created shortly - what about long URLs, how is the behavior working currently - it could result in a broken link since URLs have the `<a>` tag added.  Noting so I don't forget.