### PR TITLE
Fix documentation urls for IO library

### DIFF
--- a/libraries/tests/test_utils.py
+++ b/libraries/tests/test_utils.py
@@ -1,13 +1,17 @@
+import os
+import pytest
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
-import os
 
 from libraries.utils import (
     decode_content,
     generate_fake_email,
     generate_library_docs_url,
+    generate_library_docs_url_v2,
+    generate_library_docs_url_v3,
     get_first_last_day_last_month,
     parse_date,
+    version_within_range,
     write_content_to_tempfile,
 )
 
@@ -32,6 +36,45 @@ def test_generate_fake_email():
 def test_generate_library_docs_url():
     expected = "/doc/libs/boost_1_84_0/libs/detail/doc/html/index.html"
     assert generate_library_docs_url("boost_1_84_0", "detail") == expected
+
+
+def test_generate_library_docs_url_v2():
+    expected = "/doc/libs/1_73_0/libs/io/doc/html/io.html"
+    assert generate_library_docs_url_v2("boost_1_73_0", "io") == expected
+
+
+def test_generate_library_docs_url_v3():
+    expected = "/doc/libs/boost_1_72_0/libs/io/doc/index.html"
+    assert generate_library_docs_url_v3("boost_1_72_0", "io") == expected
+
+
+@pytest.mark.parametrize(
+    "version, min_version, max_version, expected",
+    [
+        # Case: No version restrictions
+        ("boost-1.84.0", None, None, True),
+        # Case: Version meets minimum version requirement
+        ("boost-1.84.0", "boost-1.83.0", None, True),
+        # Case: Version does not meet minimum version requirement
+        ("boost-1.82.0", "boost-1.83.0", None, False),
+        # Case: Version meets maximum version requirement
+        ("boost-1.84.0", None, "boost-1.85.0", True),
+        # Case: Version does not meet maximum version requirement
+        ("boost-1.86.0", None, "boost-1.85.0", False),
+        # Case: Version is between min and max version
+        ("boost-1.84.0", "boost-1.83.0", "boost-1.85.0", True),
+        # Case: Version is exactly min version
+        ("boost-1.83.0", "boost-1.83.0", "boost-1.85.0", True),
+        # Case: Version is exactly max version
+        ("boost-1.85.0", "boost-1.83.0", "boost-1.85.0", True),
+        # Case: Version is below min version
+        ("boost-1.82.0", "boost-1.83.0", "boost-1.85.0", False),
+        # Case: Version is above max version
+        ("boost-1.86.0", "boost-1.83.0", "boost-1.85.0", False),
+    ],
+)
+def test_version_within_range(version, min_version, max_version, expected):
+    assert version_within_range(version, min_version, max_version) == expected
 
 
 def test_get_first_last_day_last_month():

--- a/libraries/utils.py
+++ b/libraries/utils.py
@@ -29,8 +29,43 @@ def generate_fake_email(val: str) -> str:
 
 
 def generate_library_docs_url(boost_url_slug, library_slug):
-    """Generate a documentation url with a specific format"""
+    """Generate a documentation url with a specific format
+
+    General use
+    """
     return f"/doc/libs/{boost_url_slug}/libs/{library_slug}/doc/html/index.html"
+
+
+def generate_library_docs_url_v2(boost_url_slug, library_slug):
+    """ "Generate a documentation url with a specific format
+
+    For use primarily with IO, versions 1.73.0 and up
+    """
+    new_boost_url_slug = boost_url_slug.replace("boost_", "")
+    return f"/doc/libs/{new_boost_url_slug}/libs/{library_slug}/doc/html/{library_slug}.html"  # noqa
+
+
+def generate_library_docs_url_v3(boost_url_slug, library_slug):
+    """ "Generate a documentation url with a specific format
+
+    For use primarily with IO, versions 1.64.0-1.72.
+    """
+    return f"/doc/libs/{boost_url_slug}/libs/{library_slug}/doc/index.html"
+
+
+def version_within_range(
+    version: str, min_version: str = None, max_version: str = None
+):
+    """Direct string comparison, assuming 'version', 'min_version', and 'max_version'
+    follow the same format.
+
+    Expects format `boost-1.84.0`
+    """
+    if min_version and version < min_version:
+        return False
+    if max_version and version > max_version:
+        return False
+    return True
 
 
 def get_first_last_day_last_month():


### PR DESCRIPTION
- Refactor to allow for multiple documentation paths for a single library
- Add more helper functions

Also did a live test


Part of #900 

See gist: https://gist.github.com/williln/3a21931bb050e3394fb7a581eb792734

> IO -
> Boost Versions 1.64.0 through 1.72.0 the docs are here:
> https://www.boost.org/doc/libs/1_72_0/libs/io/doc/index.html
> Boost Versions 1.73.0 -> present
> https://www.boost.org/doc/libs/1_73_0/libs/io/doc/html/io.html

This PR takes care of that comment. 
