### PR TITLE
Add logic to exclude chrono/stopwatch from libraries

### DIFF
--- a/libraries/github.py
+++ b/libraries/github.py
@@ -45,6 +45,9 @@ class LibraryUpdater:
             "cmake",
             "more",
         ]
+        # Libraries to skip that are not "modules", but appear as child-libraries
+        # of other modules. Identified by the key used in the libraries.json file.
+        self.skip_libraries = ["chrono/stopwatch"]
 
     def get_library_list(self, gitmodules=None):
         """
@@ -73,10 +76,14 @@ class LibraryUpdater:
             if type(libraries_json) is list:
                 for library in libraries_json:
                     data = self.parser.parse_libraries_json(library)
+                    if data["key"] in self.skip_libraries:
+                        continue
                     libraries.append({**data, **extra_data})
 
             elif type(libraries_json) is dict:
                 data = self.parser.parse_libraries_json(libraries_json)
+                if data["key"] in self.skip_libraries:
+                    continue
                 libraries.append({**data, **extra_data})
 
         return libraries

--- a/versions/tasks.py
+++ b/versions/tasks.py
@@ -262,7 +262,9 @@ def import_library_versions(version_name, token=None, version_type="tag"):
         )
         parsed_libraries = [parser.parse_libraries_json(lib) for lib in libraries]
         for lib_data in parsed_libraries:
-            library, created = Library.objects.get_or_create(
+            if lib_data["key"] in updater.skip_libraries:
+                continue
+            library, _ = Library.objects.get_or_create(
                 key=lib_data["key"],
                 defaults={
                     "name": lib_data.get("name"),


### PR DESCRIPTION
Part of #900 

See gist: https://gist.github.com/williln/3a21931bb050e3394fb7a581eb792734#gistcomment-4877288 

> Chrono.Stopwatch -
> Importantly, it does not appear in .gitmodules.
> List of libraries page (preview): Does not appear
> List of libraries page (existing site): Does not appear
> There were some quickbook docs in the git repo boostorg/chrono/ ... /doc/stopwatches however they were not compiled or published.
> "Versions affected: 1.68.0 back to 1.63.0". If those versions completely ignored Boost.Stopwatch by not publishing docs
or linking to Boost.Stopwatch on the boost website then the same thing could be done now. Remove Boost.Stopwatch. Its source code will still be present in an archive download.

This PR addresses this comment

