### PR TITLE
900 string ref

### DIFF
--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -12,6 +12,7 @@ from .utils import (
     generate_library_docs_url,
     generate_library_docs_url_v2,
     generate_library_docs_url_v3,
+    generate_library_docs_url_string_ref,
     version_within_range,
 )
 
@@ -20,7 +21,6 @@ logger = structlog.getLogger(__name__)
 
 LIBRARY_DOCS_EXCEPTIONS = {
     "detail": [{"generator": generate_library_docs_url}],
-    "winapi": [{"generator": generate_library_docs_url}],
     "io": [
         {"generator": generate_library_docs_url_v2, "min_version": "boost_1_73_0"},
         {
@@ -29,6 +29,13 @@ LIBRARY_DOCS_EXCEPTIONS = {
             "max_version": "boost_1_72_0",
         },
     ],
+    "string-ref": [
+        {
+            "generator": generate_library_docs_url_string_ref,
+            "max_version": "boost_1_77_0",
+        }
+    ],
+    "winapi": [{"generator": generate_library_docs_url}],
 }
 
 
@@ -107,7 +114,8 @@ def get_and_store_library_version_documentation_urls_for_version(version_pk):
             ):
                 exception_url_generator = exception["generator"]
                 documentation_url = exception_url_generator(
-                    version.boost_url_slug, library_version.library.slug.lower()
+                    version.boost_url_slug,
+                    library_version.library.slug.lower().replace("-", "_"),
                 )
                 break  # Stop looking once a matching version is found
 

--- a/libraries/tests/test_utils.py
+++ b/libraries/tests/test_utils.py
@@ -9,6 +9,7 @@ from libraries.utils import (
     generate_library_docs_url,
     generate_library_docs_url_v2,
     generate_library_docs_url_v3,
+    generate_library_docs_url_string_ref,
     get_first_last_day_last_month,
     parse_date,
     version_within_range,
@@ -46,6 +47,13 @@ def test_generate_library_docs_url_v2():
 def test_generate_library_docs_url_v3():
     expected = "/doc/libs/boost_1_72_0/libs/io/doc/index.html"
     assert generate_library_docs_url_v3("boost_1_72_0", "io") == expected
+
+
+def test_generate_library_docs_ur_string_ref():
+    expected = "/doc/libs/boost_1_72_0/libs/utility/doc/html/string_ref.html"
+    assert (
+        generate_library_docs_url_string_ref("boost_1_72_0", "string_ref") == expected
+    )
 
 
 @pytest.mark.parametrize(

--- a/libraries/utils.py
+++ b/libraries/utils.py
@@ -53,6 +53,11 @@ def generate_library_docs_url_v3(boost_url_slug, library_slug):
     return f"/doc/libs/{boost_url_slug}/libs/{library_slug}/doc/index.html"
 
 
+def generate_library_docs_url_string_ref(boost_url_slug, library_slug):
+    """Generate a documentation URL for the string-ref library-versions"""
+    return f"/doc/libs/{boost_url_slug}/libs/utility/doc/html/{library_slug}.html"
+
+
 def version_within_range(
     version: str, min_version: str = None, max_version: str = None
 ):


### PR DESCRIPTION
Part of #900 
See gist: https://gist.github.com/williln/3a21931bb050e3394fb7a581eb792734 

> StringRef -
> Boost Version <= 1.77.0 the docs are here:
> https://www.boost.org/doc/libs/1_77_0/libs/utility/doc/html/string_ref.html

This does not address the StringRef docs for 1.78.0 and higher, or that it was renamed StringView. 