### PR TITLE
Add exception logic for String View docs 

### DIFF
--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -13,6 +13,7 @@ from .utils import (
     generate_library_docs_url_v2,
     generate_library_docs_url_v3,
     generate_library_docs_url_string_ref,
+    generate_library_docs_url_string_view,
     version_within_range,
 )
 
@@ -33,6 +34,12 @@ LIBRARY_DOCS_EXCEPTIONS = {
         {
             "generator": generate_library_docs_url_string_ref,
             "max_version": "boost_1_77_0",
+        }
+    ],
+    "string-view": [
+        {
+            "generator": generate_library_docs_url_string_view,
+            "max_version": "boost_1_83_0",
         }
     ],
     "winapi": [{"generator": generate_library_docs_url}],

--- a/libraries/tests/test_utils.py
+++ b/libraries/tests/test_utils.py
@@ -10,6 +10,7 @@ from libraries.utils import (
     generate_library_docs_url_v2,
     generate_library_docs_url_v3,
     generate_library_docs_url_string_ref,
+    generate_library_docs_url_string_view,
     get_first_last_day_last_month,
     parse_date,
     version_within_range,
@@ -53,6 +54,13 @@ def test_generate_library_docs_ur_string_ref():
     expected = "/doc/libs/boost_1_72_0/libs/utility/doc/html/string_ref.html"
     assert (
         generate_library_docs_url_string_ref("boost_1_72_0", "string_ref") == expected
+    )
+
+
+def test_generate_library_docs_url_string_view():
+    expected = "/doc/libs/boost_1_72_0/libs/utility/doc/html/utility/utilities/string_view.html"  # noqa
+    assert (
+        generate_library_docs_url_string_view("boost_1_72_0", "string_view") == expected
     )
 
 

--- a/libraries/utils.py
+++ b/libraries/utils.py
@@ -58,6 +58,11 @@ def generate_library_docs_url_string_ref(boost_url_slug, library_slug):
     return f"/doc/libs/{boost_url_slug}/libs/utility/doc/html/{library_slug}.html"
 
 
+def generate_library_docs_url_string_view(boost_url_slug, library_slug):
+    """Generate a documentation URL for the string-view library-versions"""
+    return f"/doc/libs/{boost_url_slug}/libs/utility/doc/html/utility/utilities/{library_slug}.html"  # noqa
+
+
 def version_within_range(
     version: str, min_version: str = None, max_version: str = None
 ):


### PR DESCRIPTION
Part of #900 

See gist https://gist.github.com/williln/3a21931bb050e3394fb7a581eb792734 

> Boost Version >= 1.78.0 the docs are here:
> https://www.boost.org/doc/libs/1_84_0/libs/utility/doc/html/utility/utilities/string_view.html
> Remove String Ref in boost >= 1.78.0 since it has been renamed string_view.

