### PR TITLE
Add exception logic for more libraries' docs links

### DIFF
--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -49,6 +49,9 @@ LIBRARY_DOCS_EXCEPTIONS = {
         }
     ],
     "detail": [{"generator": generate_library_docs_url}],
+    "interprocess": [
+        {"generator": generate_library_docs_url_v4, "max_version": "boost_1_47_0"}
+    ],
     "io": [
         {"generator": generate_library_docs_url_v2, "min_version": "boost_1_73_0"},
         {

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -52,6 +52,9 @@ LIBRARY_DOCS_EXCEPTIONS = {
     "interprocess": [
         {"generator": generate_library_docs_url_v4, "max_version": "boost_1_47_0"}
     ],
+    "intrusive": [
+        {"generator": generate_library_docs_url_v4, "max_version": "boost_1_47_0"}
+    ],
     "io": [
         {"generator": generate_library_docs_url_v2, "min_version": "boost_1_73_0"},
         {

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -66,6 +66,9 @@ LIBRARY_DOCS_EXCEPTIONS = {
     "program-options": [
         {"generator": generate_library_docs_url_v4, "max_version": "boost_1_60_0"}
     ],
+    "string-algo": [
+        {"generator": generate_library_docs_url_v4, "max_version": "boost_1_60_0"}
+    ],
     "string-ref": [
         {
             "generator": generate_library_docs_url_string_ref,

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -42,6 +42,12 @@ LIBRARY_DOCS_EXCEPTIONS = {
             "max_version": "boost_1_60_0",
         }
     ],
+    "date-time": [
+        {
+            "generator": generate_library_docs_url_v4,
+            "max_version": "boost_1_60_0",
+        }
+    ],
     "detail": [{"generator": generate_library_docs_url}],
     "io": [
         {"generator": generate_library_docs_url_v2, "min_version": "boost_1_73_0"},

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -63,6 +63,9 @@ LIBRARY_DOCS_EXCEPTIONS = {
             "max_version": "boost_1_72_0",
         },
     ],
+    "program-options": [
+        {"generator": generate_library_docs_url_v4, "max_version": "boost_1_60_0"}
+    ],
     "string-ref": [
         {
             "generator": generate_library_docs_url_string_ref,

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -36,6 +36,12 @@ LIBRARY_DOCS_EXCEPTIONS = {
             "max_version": "boost_1_60_0",
         }
     ],
+    "circular-buffer": [
+        {
+            "generator": generate_library_docs_url_v4,
+            "max_version": "boost_1_60_0",
+        }
+    ],
     "detail": [{"generator": generate_library_docs_url}],
     "io": [
         {"generator": generate_library_docs_url_v2, "min_version": "boost_1_73_0"},


### PR DESCRIPTION
Part of #900 

All of these libraries used the same link format, which is why they are in the same PR. 

- Circular Buffer
- Date Time
- Interprocess
- Intrusive
- Program Options 
- String Algo