### PR TITLE
Add exception logic for Lexical Cast, Local Function, Math Quaternion, Min Max, Numeric Conversion, Result Of, Scope Exit, Throw Exception, Type Erasure, and Type Index libraries

### DIFF
--- a/libraries/admin.py
+++ b/libraries/admin.py
@@ -136,8 +136,7 @@ class LibraryVersionAdmin(admin.ModelAdmin):
         return my_urls + urls
 
     def update_docs_urls(self, request):
-        """Run the task to refresh the documentation URLS from S3 and refresh data"""
-        import_all_library_versions.delay()
+        """Run the task to refresh the documentation URLS from S3"""
         update_library_version_documentation_urls_all_versions.delay()
         self.message_user(
             request,

--- a/libraries/tasks.py
+++ b/libraries/tasks.py
@@ -24,9 +24,13 @@ from .utils import (
     generate_library_docs_url_core,
     generate_library_docs_url_double_nested_library_htm,
     generate_library_docs_url_double_nested_library_html,
+    generate_library_docs_url_algorithm,
     generate_library_docs_url_numeric,
+    generate_library_docs_url_numeric_2,
     generate_library_docs_url_string_ref,
     generate_library_docs_url_string_view,
+    generate_library_docs_url_utility_anchor,
+    generate_library_docs_url_throwexception,
     version_within_range,
 )
 
@@ -154,6 +158,16 @@ LIBRARY_DOCS_EXCEPTIONS = {
     "iterator": [
         {"generator": generate_library_docs_url_v3, "min_version": "boost_1_52_0"},
     ],
+    "lexical-cast": [
+        {
+            "generator": generate_library_docs_url_v4,
+            "max_version": "boost_1_60_0",
+            "alternate_slug": "boost_lexical_cast",
+        }
+    ],
+    "local-function": [
+        {"generator": generate_library_docs_url, "max_version": "boost_1_60_0"}
+    ],
     "math-common-factor": [
         {
             "generator": generate_library_docs_url_math_v1,
@@ -166,6 +180,13 @@ LIBRARY_DOCS_EXCEPTIONS = {
             "generator": generate_library_docs_url_math_v1,
             "max_version": "boost_1_60_0",
             "alternate_slug": "octonions",
+        }
+    ],
+    "math-quaternion": [
+        {
+            "generator": generate_library_docs_url_math_v1,
+            "max_version": "boost_1_60_0",
+            "alternate_slug": "quaternions",
         }
     ],
     "mathspecial-functions": [
@@ -188,14 +209,37 @@ LIBRARY_DOCS_EXCEPTIONS = {
             "alternate_slug": "mem_fn",
         },
     ],
+    "min-max": [
+        {
+            "generator": generate_library_docs_url_algorithm,
+            "max_version": "boost_1_60_0",
+            "alternate_slug": "minmax",
+        }
+    ],
     "multi-array": [
         {"generator": generate_library_docs_url_v3, "max_version": "boost_1_60_0"},
     ],
     "multi-index": [
         {"generator": generate_library_docs_url_v3, "max_version": "boost_1_60_0"},
     ],
+    "numeric-conversion": [
+        {
+            "generator": generate_library_docs_url_numeric_2,
+            "max_version": "boost_1_60_0",
+            "alternate_slug": "conversion",
+        }
+    ],
     "program-options": [
         {"generator": generate_library_docs_url_v4, "max_version": "boost_1_60_0"}
+    ],
+    "result-of": [
+        {
+            "generator": generate_library_docs_url_utility_anchor,
+            "max_version": "boost_1_60_0",
+        }
+    ],
+    "scope-exit": [
+        {"generator": generate_library_docs_url, "max_version": "boost_1_60_0"}
     ],
     "smart-ptr": [
         {
@@ -225,6 +269,27 @@ LIBRARY_DOCS_EXCEPTIONS = {
             "max_version": "boost_1_83_0",
         }
     ],
+    "throwexception": [
+        {
+            "generator": generate_library_docs_url_throwexception,
+            "max_version": "boost_1_60_0",
+            "alternate_slug": "boost_throw_exception_hpp",
+        }
+    ],
+    "type-erasure": [
+        {
+            "generator": generate_library_docs_url_v4,
+            "max_version": "boost_1_60_0",
+            "alternate_slug": "boost_typeerasure",
+        }
+    ],
+    "type-index": [
+        {
+            "generator": generate_library_docs_url_v4,
+            "max_version": "boost_1_60_0",
+            "alternate_slug": "boost_typeindex",
+        }
+    ],
     # Not loading before 1.34.0
     "type-traits": [
         {"generator": generate_library_docs_url, "max_version": "boost_1_60_0"}
@@ -236,6 +301,7 @@ LIBRARY_DOCS_EXCEPTIONS = {
         {
             "generator": generate_library_docs_url_utility_v1,
             "max_version": "boost_1_60_0",
+            "alternate_slug": "value_init",
         }
     ],
 }
@@ -245,7 +311,7 @@ LIBRARY_DOCS_EXCEPTIONS = {
 def update_library_version_documentation_urls_all_versions():
     """Run the task to update all documentation URLs for all versions"""
     for version in Version.objects.all():
-        get_and_store_library_version_documentation_urls_for_version.delay(version.pk)
+        get_and_store_library_version_documentation_urls_for_version(version.pk)
 
 
 @app.task
@@ -328,7 +394,8 @@ def get_and_store_library_version_documentation_urls_for_version(version_pk):
 
         if documentation_url:
             # validate this in S3
-            content = get_content_from_s3(documentation_url)
+            key = documentation_url.split("#")
+            content = get_content_from_s3(key[0])
             if content:
                 library_version.documentation_url = documentation_url
                 library_version.save()

--- a/libraries/utils.py
+++ b/libraries/utils.py
@@ -146,6 +146,13 @@ def generate_library_docs_url_double_nested_library_htm(boost_url_slug, library_
     return f"/doc/libs/{boost_url_slug}/libs/{library_slug}/{library_slug}.htm"
 
 
+def generate_library_docs_url_algorithm(boost_url_slug, library_slug):
+    """Generate a documentation url with a specific format
+
+    First used with Min Max, versions 1.60.0 and below"""
+    return f"/doc/libs/{boost_url_slug}/libs/algorithm/{library_slug}/index.html"
+
+
 def generate_library_docs_url_numeric(boost_url_slug, library_slug):
     """Generate a documentation url with a specific format
 
@@ -153,6 +160,13 @@ def generate_library_docs_url_numeric(boost_url_slug, library_slug):
     return (
         f"/doc/libs/{boost_url_slug}/libs/numeric/{library_slug}/doc/{library_slug}.htm"
     )
+
+
+def generate_library_docs_url_numeric_2(boost_url_slug, library_slug):
+    """Generate a documentation url with a specific format
+
+    First used with Interval, versions 1.60.0 and below"""
+    return f"/doc/libs/{boost_url_slug}/libs/numeric/{library_slug}/doc/html/index.html"
 
 
 def generate_library_docs_url_string_ref(boost_url_slug, library_slug):
@@ -163,6 +177,16 @@ def generate_library_docs_url_string_ref(boost_url_slug, library_slug):
 def generate_library_docs_url_string_view(boost_url_slug, library_slug):
     """Generate a documentation URL for the string-view library-versions"""
     return f"/doc/libs/{boost_url_slug}/libs/utility/doc/html/utility/utilities/{library_slug}.html"  # noqa
+
+
+def generate_library_docs_url_throwexception(boost_url_slug, library_slug):
+    """Generate a documentation URL for the string-view library-versions"""
+    return f"/doc/libs/{boost_url_slug}/libs/exception/doc/{library_slug}.html"
+
+
+def generate_library_docs_url_utility_anchor(boost_url_slug, library_slug):
+    """Generate a documentation URL for a URL that uses an anchor"""
+    return f"/doc/libs/{boost_url_slug}/libs/utility/utility.htm#{library_slug}"
 
 
 def generate_random_string(length=4):


### PR DESCRIPTION
Part of #900 


Add exception logic for more historical library docs

- Lexical Cast
- Local Function
- Math Quaternion
- Min Max
- Numeric Conversion
- Result Of
- Scope Exit
- Throw Exception
- Type Erasure
- Type Index
- Correction for Value Initialized library

Also: 
- Remove version import from docs refresh
- Add more helper functions for docs url generation