### PR TITLE
BSL License file route + text in footer

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -14,6 +14,7 @@ from ak.views import (
     OKView,
 )
 from core.views import (
+    BSLView,
     CalendarView,
     ClearCacheView,
     DocLibsTemplateView,
@@ -81,6 +82,7 @@ urlpatterns = (
         path("feed/downloads.atom", AtomVersionFeed(), name="downloads_feed_atom"),
         path("feed/news.rss", RSSNewsFeed(), name="news_feed_rss"),
         path("feed/news.atom", AtomNewsFeed(), name="news_feed_atom"),
+        path("LICENSE_1_0.txt", BSLView, name="license"),
         path(
             "accounts/social/signup/",
             CustomSocialSignupViewView.as_view(),

--- a/core/views.py
+++ b/core/views.py
@@ -33,6 +33,17 @@ from .tasks import (
 logger = structlog.get_logger()
 
 
+def BSLView(request):
+    file_path = os.path.join(settings.BASE_DIR, "static/license.txt")
+
+    if os.path.exists(file_path):
+        with open(file_path, "r") as file:
+            content = file.read()
+        return HttpResponse(content, content_type="text/plain")
+    else:
+        raise Http404("File not found.")
+
+
 class CalendarView(TemplateView):
     template_name = "calendar.html"
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1246,10 +1246,6 @@ code,
   left: 0.25rem;
 }
 
-.isolate {
-  isolation: isolate;
-}
-
 .z-50 {
   z-index: 50;
 }
@@ -3878,8 +3874,8 @@ code,
     line-height: 2.25rem;
   }
 
-  .md\:text-6xl {
-    font-size: 3.75rem;
+  .md\:text-5xl {
+    font-size: 3rem;
     line-height: 1;
   }
 
@@ -3903,8 +3899,8 @@ code,
     line-height: 1.25rem;
   }
 
-  .md\:text-5xl {
-    font-size: 3rem;
+  .md\:text-6xl {
+    font-size: 3.75rem;
     line-height: 1;
   }
 }
@@ -4099,6 +4095,11 @@ code,
     line-height: 2.5rem;
   }
 
+  .lg\:text-6xl {
+    font-size: 3.75rem;
+    line-height: 1;
+  }
+
   .lg\:text-2xl {
     font-size: 1.5rem;
     line-height: 2rem;
@@ -4117,11 +4118,6 @@ code,
   .lg\:text-lg {
     font-size: 1.125rem;
     line-height: 1.75rem;
-  }
-
-  .lg\:text-6xl {
-    font-size: 3.75rem;
-    line-height: 1;
   }
 }
 

--- a/templates/includes/_footer.html
+++ b/templates/includes/_footer.html
@@ -11,6 +11,7 @@
       <a class="my-2 inline hover:text-orange" href="https://github.com/boostorg" target="_blank">GitHub</a>
     </div>
     <div><span class="text-sm">Website supported by grants from <a href="https://cppalliance.org/" target="_blank" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">The C++ Alliance</a>.</span></div>
+    <div><span class="text-xs italic">Distributed under the <a href="/LICENSE_1.0.txt" class="text-sky-600 dark:text-sky-300 hover:text-orange dark:hover:text-orange">Boost Software License, Version 1.0</a>.</span></div>
     {# <div><span class="text-sm"><i>Slack is a registered trademark and service mark of Slack Technologies, Inc.</i></span></div> #}
   </div>
 </footer>


### PR DESCRIPTION
Did this through Django, though it might be better to handle direct links to text files from the web server - likely not a major concern.   Will note on the issue.

- Added route to /LICENSE_1.0.txt
- Added Distributed under the Boost Software License, Version 1.0 text to footer with link to this route

resolves #978 
resolves #968 
