### PR TITLE
Add logic to skip loading some library-versions

### DIFF
--- a/libraries/constants.py
+++ b/libraries/constants.py
@@ -301,5 +301,11 @@ LIBRARY_DOCS_MISSING = {
     "winapi": [{"min_version": "boost-1.56.0", "max_version": "boost-1.60.0"}],
 }
 
+# Library-versions that we should not attempt to load at all
+SKIP_LIBRARY_VERSIONS = {
+    "algorithm": [{"max_version": "boost-1.49.0"}],
+    "identity-type": [{"max_version": "boost-1.49.0"}],
+}
+
 # List of versions for which we know docs are missing
 VERSION_DOCS_MISSING = ["boost-1.33.0"]


### PR DESCRIPTION
Part of #900 

Adds logic to skip some specific library-versions in the load script. 

_note_ These will need to be manually deleted from the DB (via the admin) but they won't load again after that. 